### PR TITLE
Fix SSE stream breaking on first tool result

### DIFF
--- a/chat.py
+++ b/chat.py
@@ -470,15 +470,11 @@ async def create_sse_stream(
                         yield SSEEvent("text", block.text).serialize()
 
             elif isinstance(msg, ResultMessage):
-                # Check for any pending render_html results
+                # Emit any pending render_html artifacts from this turn
                 renders = _pending_renders_var.get({})
                 for render_data in renders.values():
                     yield SSEEvent("artifact", render_data).serialize()
                 _pending_renders_var.set({})
-
-                # Check for download URLs in the result
-                # (handled via tool results already, but emit done)
-                break
 
             elif isinstance(msg, SystemMessage):
                 # System messages (init, etc.) — skip


### PR DESCRIPTION
## Summary
- Remove `break` on first `ResultMessage` in SSE generator
- The break cut the stream after the first tool turn, losing artifacts and text from subsequent agent turns
- This caused `render_html` artifacts to never reach the frontend

## Test plan
- [ ] Ask the chat agent to render an HTML chart → iframe should appear
- [ ] Multi-turn tool calls should stream all results, not just the first