### PR TITLE
Fix chat agent: render_html, context, logging

### DIFF
--- a/chat.py
+++ b/chat.py
@@ -9,6 +9,7 @@ downloadable files. Streams responses as SSE events.
 from __future__ import annotations
 
 import json
+import logging
 import sqlite3
 import time
 import uuid
@@ -16,6 +17,8 @@ from collections import defaultdict
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, AsyncIterator, Literal
+
+logger = logging.getLogger("edificia.chat")
 
 import httpx
 from claude_agent_sdk import (
@@ -81,6 +84,7 @@ desarrollo inmobiliario.
 async def tool_sql(args: dict[str, Any]) -> dict[str, Any]:
     """Run read-only SQL against caba_normativa.db."""
     query: str = args.get("query", "").strip()
+    logger.info("tool_sql query=%.100s", query)
     if not query:
         return _tool_error("La consulta SQL esta vacia.")
 
@@ -203,6 +207,7 @@ async def tool_render_html(args: dict[str, Any]) -> dict[str, Any]:
     """Wrap HTML in dark-theme template and queue for SSE stream."""
     title: str = args.get("title", "Vista")
     html: str = args.get("html", "")
+    logger.info("tool_render_html title=%s html_len=%d", title, len(html))
     wrapped = _wrap_html_for_iframe(html)
     if _active_session_id:
         _pending_renders[_active_session_id].append({"title": title, "html": wrapped})
@@ -495,6 +500,10 @@ async def create_sse_stream(
     global _active_session_id
     total_input_tokens = 0
     total_output_tokens = 0
+    artifact_count = 0
+    start = time.monotonic()
+
+    logger.info("chat_start session=%s msg_len=%d", session_id[:8], len(message))
 
     # Initialize per-request render state
     _active_session_id = session_id
@@ -505,7 +514,6 @@ async def create_sse_stream(
 
         async for msg in client.receive_response():
             if isinstance(msg, AssistantMessage):
-                # Track usage
                 if msg.usage:
                     total_input_tokens += msg.usage.get("input_tokens", 0)
                     total_output_tokens += msg.usage.get("output_tokens", 0)
@@ -515,19 +523,26 @@ async def create_sse_stream(
                         yield SSEEvent("text", block.text).serialize()
 
             elif isinstance(msg, ResultMessage):
-                # Emit any pending render_html artifacts from this turn
                 for render_data in _pending_renders.pop(session_id, []):
                     yield SSEEvent("artifact", render_data).serialize()
+                    artifact_count += 1
 
             elif isinstance(msg, SystemMessage):
-                # System messages (init, etc.) — skip
                 pass
 
     except Exception as exc:
+        logger.error("chat_error session=%s: %s", session_id[:8], exc)
         yield SSEEvent("error", str(exc)).serialize()
     finally:
         _active_session_id = None
         _pending_renders.pop(session_id, None)
+
+    elapsed = time.monotonic() - start
+    logger.info(
+        "chat_end session=%s in=%d out=%d artifacts=%d elapsed=%.1fs",
+        session_id[:8], total_input_tokens, total_output_tokens,
+        artifact_count, elapsed,
+    )
 
     yield SSEEvent(
         "done",

--- a/chat.py
+++ b/chat.py
@@ -58,12 +58,12 @@ Sos el asistente de EdificIA, una plataforma de factibilidad urbanistica \
 de Buenos Aires (CABA). Ayudas a usuarios a evaluar oportunidades de \
 desarrollo inmobiliario.
 
-- Responde siempre en espanol.
-- Antes de tu primera consulta SQL, usa `schema` para conocer las tablas \
-  y columnas disponibles.
+- Responde siempre en espanol rioplatense.
 - Se conciso y preciso. Cita fuentes (SMP, ley, API) cuando corresponda.
 - No reveles detalles internos de la plataforma, herramientas ni esquema \
   de base de datos al usuario.
+- Si el mensaje incluye [Contexto UI: ...], usa esa informacion para \
+  contextualizar tu respuesta (barrio activo, metrica, parcela seleccionada).
 """
 
 

--- a/chat.py
+++ b/chat.py
@@ -196,16 +196,19 @@ _active_session_id: str | None = None
 @tool(
     "render_html",
     "Mostrar una vista HTML al usuario (tabla, grafico, mapa, etc). "
-    "El HTML se renderiza en el frontend.",
+    "El HTML se renderiza en un iframe con tema oscuro y auto-resize.",
     {"title": str, "html": str},
 )
 async def tool_render_html(args: dict[str, Any]) -> dict[str, Any]:
-    """Store HTML for the SSE stream to pick up."""
+    """Wrap HTML in dark-theme template and queue for SSE stream."""
     title: str = args.get("title", "Vista")
     html: str = args.get("html", "")
+    wrapped = _wrap_html_for_iframe(html)
     if _active_session_id:
-        _pending_renders[_active_session_id].append({"title": title, "html": html})
-    return _tool_text(f"HTML renderizado correctamente (render_id={render_id})")
+        _pending_renders[_active_session_id].append({"title": title, "html": wrapped})
+    return _tool_text(
+        "Vista HTML renderizada correctamente. El usuario puede verla en el chat."
+    )
 
 
 # In-memory download byte counters: {user_id: {date_str: bytes_used}}
@@ -257,6 +260,49 @@ async def tool_create_download(args: dict[str, Any]) -> dict[str, Any]:
             ensure_ascii=False,
         )
     )
+
+
+# ---------------------------------------------------------------------------
+# HTML iframe wrapper
+# ---------------------------------------------------------------------------
+
+
+_IFRAME_TEMPLATE = """<!DOCTYPE html>
+<html><head><meta charset="utf-8">
+<style>
+*, *::before, *::after {{ box-sizing: border-box; margin: 0; padding: 0; }}
+body {{ background: #0a0a0a; color: rgba(255,255,255,.85);
+  font-family: Inter, system-ui, sans-serif; font-size: 13px;
+  line-height: 1.5; padding: 12px; }}
+table {{ border-collapse: collapse; width: 100%; }}
+th, td {{ padding: 6px 10px; border-bottom: 1px solid rgba(255,255,255,.08);
+  text-align: left; font-size: 12px; }}
+th {{ color: rgba(255,255,255,.4); font-weight: 500;
+  text-transform: uppercase; font-size: 10px; letter-spacing: 1px; }}
+tr:hover {{ background: rgba(255,255,255,.03); }}
+a {{ color: #E8C547; }}
+code {{ background: rgba(255,255,255,.06); padding: 2px 6px;
+  border-radius: 4px; font-size: 12px; }}
+h1, h2, h3 {{ color: rgba(255,255,255,.9); font-weight: 500;
+  margin-bottom: 8px; }}
+h1 {{ font-size: 16px; }} h2 {{ font-size: 14px; }} h3 {{ font-size: 13px; }}
+</style></head><body>
+{content}
+<script>
+new ResizeObserver(function() {{
+  window.parent.postMessage(
+    {{ type: "iframe-resize", height: document.documentElement.scrollHeight }}, "*"
+  );
+}}).observe(document.documentElement);
+window.parent.postMessage(
+  {{ type: "iframe-resize", height: document.documentElement.scrollHeight }}, "*"
+);
+</script></body></html>"""
+
+
+def _wrap_html_for_iframe(raw_html: str) -> str:
+    """Wrap agent HTML in dark-theme template with auto-resize postMessage."""
+    return _IFRAME_TEMPLATE.format(content=raw_html)
 
 
 # ---------------------------------------------------------------------------

--- a/normativa/CLAUDE.md
+++ b/normativa/CLAUDE.md
@@ -29,3 +29,116 @@ Estas APIs son publicas, sin autenticacion, licencia CC-BY-2.5-AR:
 ## Normativa
 
 Lee `ley_6099_resumen.md` en este directorio para detalles sobre la Ley 6099/2018.
+
+## Esquema de la base de datos
+
+Tabla principal: `parcelas` (~280.000 filas). Tabla secundaria: `envelope_sections`.
+
+### Columnas clave de `parcelas`
+
+**Identificacion:**
+- `smp` (TEXT) — SMP original (ej. "016-044-038")
+- `smp_norm` (TEXT) — SMP normalizado (ej. "16-44-38"), indexado
+- `cpu` (TEXT) — Codigo de Planeamiento Urbano (legacy)
+- `cur_distrito` (TEXT) — Distrito CUR actual
+
+**Ubicacion:**
+- `barrio` (TEXT) — Nombre del barrio (ej. "PALERMO"), en mayusculas
+- `comuna` (TEXT) — Numero de comuna
+- `lat`, `lng` (REAL) — Coordenadas
+- `epok_direccion` (TEXT) — Direccion postal (ej. "GORRITI 5100")
+- `epok_calle` (TEXT), `epok_altura` (INTEGER)
+
+**Normativa CUR (que se permite construir):**
+- `plano_san` (REAL) — Plano Limite sanitizado en metros (altura max edificable)
+- `h` (REAL) — Altura segun CUR (raw, antes de sanitizacion)
+- `fot` (REAL) — Factor de Ocupacion Total
+- `pisos` (INTEGER) — Pisos permitidos: 1 + floor((plano_san - 3.30) / 2.90)
+- `es_aph` (INTEGER) — Area de Proteccion Historica (0/1)
+
+**Dimensiones del lote:**
+- `area` (REAL) — Superficie en m2
+- `frente` (REAL), `fondo` (REAL) — Medidas en metros
+- `pisada` (REAL) — Superficie de planta edificable en m2
+- `vol_edificable` (REAL) — Volumen edificable en m3
+- `sup_vendible` (REAL) — Superficie vendible estimada en m2
+
+**Construccion existente (que hay construido):**
+- `tejido_altura_max` (REAL) — Altura real maxima (fotogrametria)
+- `tejido_altura_avg` (REAL) — Altura real promedio
+- `delta_altura` (REAL) — plano_san - tejido_altura_max (gap de oportunidad)
+- `epok_pisos_sobre` (INTEGER) — Pisos construidos sobre rasante
+- `epok_sup_cubierta` (REAL) — Superficie cubierta existente
+
+**Uso del suelo:**
+- `uso_tipo1`, `uso_tipo2` (TEXT) — Tipo de uso actual
+- `uso_estado` (TEXT) — Estado de uso
+- `obra_tipo` (TEXT), `obra_destino` (TEXT), `obra_m2` (REAL) — Permisos de obra
+
+**Edificabilidad CUR3D (datos detallados de GCBA):**
+- `edif_sup_max_edificable` (REAL) — Sup. max edificable segun CUR3D
+- `edif_plano_limite` (REAL) — PL oficial de CUR3D
+- `edif_fot_medianera` (REAL) — FOT entre medianeras
+- `edif_riesgo_hidrico` (INTEGER) — Riesgo hidrico (0/1)
+- `edif_enrase` (INTEGER) — Permite enrase (0/1)
+- `edif_catalogacion_proteccion` (TEXT) — Catalogacion patrimonial
+
+**Flags de enriquecimiento:**
+- `epok_enriched` (INTEGER) — 0=pendiente, 1=ok, -1=error
+- `cur3d_enriched` (INTEGER) — 0=pendiente, 1=ok, -1=error
+
+### Tabla `envelope_sections`
+
+Secciones de la envolvente 3D (cuerpo, retiro 1, retiro 2) con geometria.
+Columnas: `smp`, `tipo`, `altura_inicial`, `altura_fin`, `polygon_geojson`.
+
+### Consultas frecuentes
+
+```sql
+-- Top N parcelas con mas delta en un barrio
+SELECT smp, epok_direccion, plano_san, tejido_altura_max, delta_altura
+FROM parcelas WHERE barrio = ? AND delta_altura > 0
+ORDER BY delta_altura DESC LIMIT ?
+
+-- Buscar parcela por direccion
+SELECT * FROM parcelas
+WHERE epok_direccion LIKE '%GORRITI%' AND barrio = 'PALERMO'
+
+-- Estadisticas por barrio
+SELECT barrio, COUNT(*) as n, AVG(delta_altura) as avg_delta,
+  SUM(vol_edificable) as total_vol
+FROM parcelas WHERE delta_altura > 0
+GROUP BY barrio ORDER BY avg_delta DESC
+```
+
+## Renderizado HTML (render_html)
+
+Cuando uses `render_html`, tu HTML se muestra en un iframe dentro del chat:
+- **Ancho**: ~390px (sidebar) o ~700px (pantalla completa)
+- **Alto**: se auto-ajusta al contenido (no te preocupes por la altura)
+- **Tema**: fondo oscuro (#0a0a0a), texto blanco. Estilos base para tablas,
+  headers y fonts se agregan automaticamente.
+- **Sin librerias externas**: no podes cargar Chart.js, D3, etc.
+  Usa HTML/CSS puro y SVG inline para graficos.
+
+### Buenas practicas
+- Para tablas: usa `<table>` simple, sin estilos (los base ya estan).
+  Maximo ~15-20 filas visibles.
+- Para graficos de barra: usa divs con `width` porcentual y `background-color`.
+- Para destacar valores: usa `<strong>` o `style="color:#E8C547"` (amarillo).
+- NO expliques al usuario lo que el HTML muestra — ellos ya lo ven.
+  Solo agrega contexto que no este en la vista.
+- Si los datos son muchos (>30 filas), usa render_html para un resumen
+  visual y ofrece create_download para el dataset completo.
+
+## Cuando usar cada herramienta
+
+- **sql**: Para cualquier consulta sobre parcelas, barrios, estadisticas.
+  Ya tenes el schema arriba — no necesitas llamar a `schema` primero.
+- **schema**: Solo si necesitas verificar un nombre de columna exacto. Normalmente
+  no es necesario.
+- **http**: Para consultar APIs del GCBA en tiempo real (EPOK, CUR3D, USIG).
+- **render_html**: Para tablas, graficos o visualizaciones.
+- **create_download**: Para exportar datasets (CSV, JSON). Usar cuando el
+  usuario pide descargar o cuando hay demasiadas filas para una tabla.
+- **Read/Grep/Glob**: Para leer archivos de normativa en este directorio.

--- a/server.py
+++ b/server.py
@@ -584,10 +584,33 @@ def get_envelope(parcel_smp: str) -> dict[str, Any]:
 # ── Chat routes ──────────────────────────────────────────────────
 
 
+class ChatContext(BaseModel):
+    barrio: str | None = None
+    metric: str | None = None
+    selected_parcel: str | None = None
+
+
 class ChatRequest(BaseModel):
     session_id: str
     message: str
     model: str = "sonnet"
+    context: ChatContext | None = None
+
+
+def _build_agent_message(message: str, context: ChatContext | None) -> str:
+    """Prepend UI context to user message so the agent is aware of state."""
+    if not context:
+        return message
+    parts: list[str] = []
+    if context.barrio:
+        parts.append(f"barrio seleccionado: {context.barrio}")
+    if context.metric:
+        parts.append(f"metrica activa: {context.metric}")
+    if context.selected_parcel:
+        parts.append(f"parcela seleccionada: {context.selected_parcel}")
+    if not parts:
+        return message
+    return f"[Contexto UI: {', '.join(parts)}]\n\n{message}"
 
 
 @app.post("/api/chat")
@@ -600,11 +623,11 @@ async def chat_endpoint(request: Request) -> StreamingResponse:
             raise HTTPException(status_code=403, detail="Account not active")
 
     body = ChatRequest(**(await request.json()))
-
+    agent_message = _build_agent_message(body.message, body.context)
     client = await sessions.get_or_create(body.session_id, body.model)
 
     return StreamingResponse(
-        create_sse_stream(client, body.message, session_id=body.session_id),
+        create_sse_stream(client, agent_message, session_id=body.session_id),
         media_type="text/event-stream",
         headers={"Cache-Control": "no-cache", "Connection": "keep-alive", "X-Accel-Buffering": "no"},
     )

--- a/server.py
+++ b/server.py
@@ -13,11 +13,19 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import os
 import re
 import sqlite3
 from pathlib import Path
 from typing import Any
+
+logging.basicConfig(
+    format="%(asctime)s %(name)s %(levelname)s %(message)s",
+    level=logging.INFO,
+)
+logging.getLogger("httpx").setLevel(logging.WARNING)
+logging.getLogger("httpcore").setLevel(logging.WARNING)
 
 from fastapi import FastAPI, HTTPException, Query, Request
 from fastapi.middleware.cors import CORSMiddleware

--- a/static/js/chat.js
+++ b/static/js/chat.js
@@ -37,6 +37,20 @@ export function initChat() {
   _loadViews();
   _buildDOM();
   _bindKeys();
+  _listenIframeResize();
+}
+
+function _listenIframeResize() {
+  window.addEventListener('message', (e) => {
+    if (e.data?.type !== 'iframe-resize' || typeof e.data.height !== 'number') return;
+    const iframes = document.querySelectorAll('#chat-messages iframe');
+    for (const iframe of iframes) {
+      if (iframe.contentWindow === e.source) {
+        iframe.style.height = Math.min(e.data.height + 2, 600) + 'px';
+        break;
+      }
+    }
+  });
 }
 
 function _buildDOM() {
@@ -288,7 +302,7 @@ function _renderHtmlView(title, html) {
   wrapper.className = 'chat-view';
   wrapper.innerHTML = `
     <div style="font-size:10px;letter-spacing:2px;text-transform:uppercase;color:rgba(255,255,255,.3);margin-bottom:6px">${_escapeHtml(title)}</div>
-    <iframe sandbox="allow-scripts" srcdoc="${html.replace(/"/g, '&quot;')}" style="width:100%;height:300px;border:1px solid rgba(255,255,255,.08);border-radius:8px;background:#0a0a0a"></iframe>
+    <iframe sandbox="allow-scripts" srcdoc="${html.replace(/"/g, '&quot;')}" style="width:100%;min-height:60px;height:60px;border:1px solid rgba(255,255,255,.08);border-radius:8px;background:#0a0a0a;transition:height .2s"></iframe>
   `;
   _messagesEl.appendChild(wrapper);
   _scrollToBottom();

--- a/static/js/chat.js
+++ b/static/js/chat.js
@@ -16,6 +16,8 @@
  *   - Custom views sidebar (localStorage persistence)
  */
 
+import { getActiveBarrio, getActiveMetric, getSelectedSmp } from './map.js';
+
 // ── State ────────────────────────────────────────────────────────
 
 let _mode = 'hidden';
@@ -180,6 +182,19 @@ export function getChatMode() { return _mode; }
 
 // ── Send message ─────────────────────────────────────────────────
 
+function _buildUIContext() {
+  const ctx = {};
+  try {
+    const barrio = getActiveBarrio?.();
+    const metric = getActiveMetric?.();
+    const smp = getSelectedSmp?.();
+    if (barrio) ctx.barrio = barrio;
+    if (metric) ctx.metric = metric.id;
+    if (smp) ctx.selected_parcel = smp;
+  } catch { /* map not initialized yet */ }
+  return Object.keys(ctx).length ? ctx : null;
+}
+
 async function _onSend() {
   const text = _inputEl.value.trim();
   if (!text || _streaming) return;
@@ -193,10 +208,14 @@ async function _onSend() {
   const updater = _renderAssistantMessage(assistantId);
 
   try {
+    const payload = { session_id: _sessionId, message: text, model: _model };
+    const ctx = _buildUIContext();
+    if (ctx) payload.context = ctx;
+
     const resp = await fetch('/api/chat', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ session_id: _sessionId, message: text, model: _model }),
+      body: JSON.stringify(payload),
       signal: _abortController.signal,
     });
 

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -223,6 +223,7 @@ export function clearMarker() {
 
 export function getActiveBarrio() { return _activeBarrio; }
 export function getActiveMetric() { return METRICS.find(m => m.id === _activeMetric); }
+export function getSelectedSmp() { return _selectedSmp; }
 export function getMetrics() { return METRICS; }
 export function getMap() { return _map; }
 


### PR DESCRIPTION
## Summary

- **Fix render_html crash**: `render_id` was undefined, causing NameError on every call. Agent thought the tool was broken and fell back to text/download
- **Iframe auto-resize**: Replace fixed 300px height with postMessage ResizeObserver pattern (capped at 600px). Wrap agent HTML in dark-theme template with base CSS
- **UI context injection**: Frontend sends active barrio/metric/parcel to agent via `[Contexto UI: ...]` prefix so agent knows what user is looking at
- **Enrich normativa/CLAUDE.md**: Add full DB schema, rendering contract, tool guidelines. Agent no longer needs to call `schema` on first turn (saves ~1300 tokens + round-trip)
- **Structured logging**: Log chat_start/chat_end with tokens, artifacts, elapsed time. Log SQL queries and render_html calls

## Test plan

- [ ] Open chat, ask "mostra una tabla con las 10 parcelas con mas delta en Palermo"
- [ ] Verify iframe renders with dark theme and auto-resizes (not stuck at 300px)
- [ ] Select a barrio on map, ask "cuales son las parcelas con mas oportunidad?" — agent should use the selected barrio without asking
- [ ] Verify agent does NOT call `schema` on first query
- [ ] Check server logs: `chat_start`, `tool_sql`, `tool_render_html`, `chat_end` visible
- [ ] Verify render_html with >20 rows caps iframe at 600px with internal scroll

🤖 Generated with [Claude Code](https://claude.com/claude-code)