### PR TITLE
Add chat persistence + history API

### DIFF
--- a/chat.py
+++ b/chat.py
@@ -65,8 +65,6 @@ desarrollo inmobiliario.
 - Se conciso y preciso. Cita fuentes (SMP, ley, API) cuando corresponda.
 - No reveles detalles internos de la plataforma, herramientas ni esquema \
   de base de datos al usuario.
-- Si el mensaje incluye [Contexto UI: ...], usa esa informacion para \
-  contextualizar tu respuesta (barrio activo, metrica, parcela seleccionada).
 """
 
 
@@ -490,20 +488,30 @@ class SSEEvent:
 
 
 async def create_sse_stream(
-    client: ClaudeSDKClient, message: str, session_id: str = ""
+    client: ClaudeSDKClient,
+    message: str,
+    session_id: str = "",
+    user_id: int | None = None,
+    model: str = "sonnet",
 ) -> AsyncIterator[str]:
     """Send a message to the agent and yield SSE event strings.
 
-    Yields serialized SSE events for each piece of the agent response:
-    text chunks, rendered HTML artifacts, errors, and a final "done" event.
+    Persists user/assistant messages and artifacts to chat_entries.
     """
     global _active_session_id
     total_input_tokens = 0
     total_output_tokens = 0
     artifact_count = 0
+    assistant_text = ""
     start = time.monotonic()
 
     logger.info("chat_start session=%s msg_len=%d", session_id[:8], len(message))
+
+    # Persist user message and upsert session
+    _persist_entry(
+        session_id, "user", message,
+        user_id=user_id, preview=message[:80], model=model,
+    )
 
     # Initialize per-request render state
     _active_session_id = session_id
@@ -520,12 +528,27 @@ async def create_sse_stream(
 
                 for block in msg.content:
                     if isinstance(block, TextBlock):
+                        assistant_text += block.text
                         yield SSEEvent("text", block.text).serialize()
 
             elif isinstance(msg, ResultMessage):
+                # Persist assistant text accumulated so far
+                if assistant_text:
+                    _persist_entry(session_id, "assistant", assistant_text)
+                    assistant_text = ""
+
                 for render_data in _pending_renders.pop(session_id, []):
                     yield SSEEvent("artifact", render_data).serialize()
                     artifact_count += 1
+                    _persist_entry(
+                        session_id, "report",
+                        json.dumps({
+                            "title": render_data["title"],
+                            "html": render_data["html"],
+                            "source": "agent",
+                            "size": len(render_data["html"]),
+                        }, ensure_ascii=False),
+                    )
 
             elif isinstance(msg, SystemMessage):
                 pass
@@ -534,6 +557,9 @@ async def create_sse_stream(
         logger.error("chat_error session=%s: %s", session_id[:8], exc)
         yield SSEEvent("error", str(exc)).serialize()
     finally:
+        # Persist any remaining assistant text
+        if assistant_text:
+            _persist_entry(session_id, "assistant", assistant_text)
         _active_session_id = None
         _pending_renders.pop(session_id, None)
 
@@ -551,6 +577,67 @@ async def create_sse_stream(
             "output_tokens": total_output_tokens,
         },
     ).serialize()
+
+
+# ---------------------------------------------------------------------------
+# Chat persistence
+# ---------------------------------------------------------------------------
+
+
+def init_chat_tables() -> None:
+    """Create chat_sessions and chat_entries tables if they don't exist."""
+    conn = sqlite3.connect(str(DB_PATH), timeout=SQL_TIMEOUT_S)
+    try:
+        conn.executescript("""
+            CREATE TABLE IF NOT EXISTS chat_sessions (
+                id TEXT PRIMARY KEY,
+                user_id INTEGER NOT NULL,
+                created_at REAL DEFAULT (strftime('%s','now')),
+                last_used REAL DEFAULT (strftime('%s','now')),
+                preview TEXT,
+                model TEXT DEFAULT 'sonnet',
+                FOREIGN KEY (user_id) REFERENCES users(id)
+            );
+            CREATE TABLE IF NOT EXISTS chat_entries (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                session_id TEXT NOT NULL,
+                kind TEXT NOT NULL,
+                content TEXT NOT NULL,
+                created_at REAL DEFAULT (strftime('%s','now')),
+                FOREIGN KEY (session_id) REFERENCES chat_sessions(id)
+            );
+        """)
+    finally:
+        conn.close()
+
+
+def _persist_entry(
+    session_id: str, kind: str, content: str,
+    user_id: int | None = None, preview: str | None = None,
+    model: str = "sonnet",
+) -> None:
+    """Save a chat entry and upsert the session row."""
+    conn = sqlite3.connect(str(DB_PATH), timeout=SQL_TIMEOUT_S)
+    try:
+        now = time.time()
+        if user_id is not None:
+            conn.execute(
+                "INSERT INTO chat_sessions (id, user_id, created_at, last_used, preview, model) "
+                "VALUES (?, ?, ?, ?, ?, ?) "
+                "ON CONFLICT(id) DO UPDATE SET last_used=?, preview=COALESCE(preview, ?)",
+                (session_id, user_id, now, now, preview, model, now, preview),
+            )
+        else:
+            conn.execute(
+                "UPDATE chat_sessions SET last_used=? WHERE id=?", (now, session_id)
+            )
+        conn.execute(
+            "INSERT INTO chat_entries (session_id, kind, content) VALUES (?, ?, ?)",
+            (session_id, kind, content),
+        )
+        conn.commit()
+    finally:
+        conn.close()
 
 
 # ---------------------------------------------------------------------------

--- a/server.py
+++ b/server.py
@@ -56,6 +56,8 @@ from chat import (
     SessionManager,
     cleanup_old_downloads,
     create_sse_stream,
+    init_chat_tables,
+    _persist_entry,
 )
 
 
@@ -121,6 +123,7 @@ sessions = SessionManager()
 @app.on_event("startup")
 def startup():
     init_users_table()
+    init_chat_tables()
     DOWNLOADS_DIR.mkdir(parents=True, exist_ok=True)
 
 
@@ -592,53 +595,87 @@ def get_envelope(parcel_smp: str) -> dict[str, Any]:
 # ── Chat routes ──────────────────────────────────────────────────
 
 
-class ChatContext(BaseModel):
-    barrio: str | None = None
-    metric: str | None = None
-    selected_parcel: str | None = None
-
-
 class ChatRequest(BaseModel):
     session_id: str
     message: str
     model: str = "sonnet"
-    context: ChatContext | None = None
 
 
-def _build_agent_message(message: str, context: ChatContext | None) -> str:
-    """Prepend UI context to user message so the agent is aware of state."""
-    if not context:
-        return message
-    parts: list[str] = []
-    if context.barrio:
-        parts.append(f"barrio seleccionado: {context.barrio}")
-    if context.metric:
-        parts.append(f"metrica activa: {context.metric}")
-    if context.selected_parcel:
-        parts.append(f"parcela seleccionada: {context.selected_parcel}")
-    if not parts:
-        return message
-    return f"[Contexto UI: {', '.join(parts)}]\n\n{message}"
+class EntryRequest(BaseModel):
+    session_id: str
+    kind: str
+    content: str
 
 
 @app.post("/api/chat")
 async def chat_endpoint(request: Request) -> StreamingResponse:
+    user = get_current_user(request)
+    user_id = user["id"] if user else None
     if os.environ.get("GOOGLE_CLIENT_ID"):
-        user = get_current_user(request)
         if not user:
             raise HTTPException(status_code=401, detail="Not authenticated")
         if not user.get("activo"):
             raise HTTPException(status_code=403, detail="Account not active")
 
     body = ChatRequest(**(await request.json()))
-    agent_message = _build_agent_message(body.message, body.context)
     client = await sessions.get_or_create(body.session_id, body.model)
 
     return StreamingResponse(
-        create_sse_stream(client, agent_message, session_id=body.session_id),
+        create_sse_stream(
+            client, body.message,
+            session_id=body.session_id, user_id=user_id, model=body.model,
+        ),
         media_type="text/event-stream",
         headers={"Cache-Control": "no-cache", "Connection": "keep-alive", "X-Accel-Buffering": "no"},
     )
+
+
+@app.get("/api/chat/sessions")
+def list_chat_sessions(request: Request) -> list[dict[str, Any]]:
+    """List the authenticated user's chat sessions."""
+    user = require_active_user(request)
+    conn = db_connect()
+    try:
+        rows = conn.execute(
+            "SELECT id, created_at, last_used, preview, model "
+            "FROM chat_sessions WHERE user_id = ? ORDER BY last_used DESC LIMIT 50",
+            (user["id"],),
+        ).fetchall()
+        return [dict(r) for r in rows]
+    finally:
+        conn.close()
+
+
+@app.get("/api/chat/sessions/{session_id}")
+def get_chat_session(session_id: str, request: Request) -> dict[str, Any]:
+    """Get all entries for a chat session."""
+    user = require_active_user(request)
+    conn = db_connect()
+    try:
+        session = conn.execute(
+            "SELECT * FROM chat_sessions WHERE id = ? AND user_id = ?",
+            (session_id, user["id"]),
+        ).fetchone()
+        if not session:
+            raise HTTPException(status_code=404, detail="Session not found")
+        entries = conn.execute(
+            "SELECT id, kind, content, created_at FROM chat_entries "
+            "WHERE session_id = ? ORDER BY id", (session_id,),
+        ).fetchall()
+        return {"session": dict(session), "entries": [dict(e) for e in entries]}
+    finally:
+        conn.close()
+
+
+@app.post("/api/chat/entries")
+def save_chat_entry(body: EntryRequest, request: Request) -> dict[str, bool]:
+    """Save a programmatic entry (map click, barrio selection). No LLM call."""
+    user = get_current_user(request)
+    user_id = user["id"] if user else None
+    _persist_entry(
+        body.session_id, body.kind, body.content, user_id=user_id,
+    )
+    return {"ok": True}
 
 
 @app.delete("/api/chat/{session_id}")

--- a/static/js/chat.js
+++ b/static/js/chat.js
@@ -16,8 +16,6 @@
  *   - Custom views sidebar (localStorage persistence)
  */
 
-import { getActiveBarrio, getActiveMetric, getSelectedSmp } from './map.js';
-
 // ── State ────────────────────────────────────────────────────────
 
 let _mode = 'hidden';
@@ -182,19 +180,6 @@ export function getChatMode() { return _mode; }
 
 // ── Send message ─────────────────────────────────────────────────
 
-function _buildUIContext() {
-  const ctx = {};
-  try {
-    const barrio = getActiveBarrio?.();
-    const metric = getActiveMetric?.();
-    const smp = getSelectedSmp?.();
-    if (barrio) ctx.barrio = barrio;
-    if (metric) ctx.metric = metric.id;
-    if (smp) ctx.selected_parcel = smp;
-  } catch { /* map not initialized yet */ }
-  return Object.keys(ctx).length ? ctx : null;
-}
-
 async function _onSend() {
   const text = _inputEl.value.trim();
   if (!text || _streaming) return;
@@ -208,14 +193,10 @@ async function _onSend() {
   const updater = _renderAssistantMessage(assistantId);
 
   try {
-    const payload = { session_id: _sessionId, message: text, model: _model };
-    const ctx = _buildUIContext();
-    if (ctx) payload.context = ctx;
-
     const resp = await fetch('/api/chat', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(payload),
+      body: JSON.stringify({ session_id: _sessionId, message: text, model: _model }),
       signal: _abortController.signal,
     });
 

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -223,7 +223,6 @@ export function clearMarker() {
 
 export function getActiveBarrio() { return _activeBarrio; }
 export function getActiveMetric() { return METRICS.find(m => m.id === _activeMetric); }
-export function getSelectedSmp() { return _selectedSmp; }
 export function getMetrics() { return METRICS; }
 export function getMap() { return _map; }
 


### PR DESCRIPTION
## Summary

- **Unified entries table**: `chat_sessions` + `chat_entries` in SQLite, tied to `user_id`. Every chat entry (user message, assistant response, report, download) is one row with a `kind` field.
- **Persistence in SSE stream**: `create_sse_stream` now saves user messages, assistant text, and artifacts as they stream.
- **History API**: `GET /api/chat/sessions` (list), `GET /api/chat/sessions/{id}` (full timeline), `POST /api/chat/entries` (save programmatic messages from map clicks).
- **Remove context injection**: Deleted `[Contexto UI: ...]` prefix — context will be visible reports in the conversation instead of hidden injection.

## Test plan

- [ ] Send chat message → verify `chat_sessions` and `chat_entries` rows created
- [ ] Agent produces artifact → verify `chat_entries` row with kind='report'
- [ ] `GET /api/chat/sessions` → returns authenticated user's sessions
- [ ] `GET /api/chat/sessions/{id}` → returns full entry timeline
- [ ] `POST /api/chat/entries` → saves programmatic entry (for future map click integration)
- [ ] Different user can't access another's sessions (auth check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)