### PR TITLE
Hook map clicks to chat reports

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -13,6 +13,7 @@
  */
 
 import * as Map from './map.js';
+import { addReport, addInfoMessage, getChatMode } from './chat.js';
 
 // ── DOM helpers ──────────────────────────────────────────────────
 
@@ -358,6 +359,27 @@ function showParcelFromMap(props) {
   // Links
   $('parcelLink').href = `https://ciudad3d.buenosaires.gob.ar/?smp=${encodeURIComponent(props.smp)}`;
 
+  // Send parcel report to chat (0 LLM tokens)
+  if (getChatMode() !== 'hidden') {
+    const delta = props.tj ? (props.pl - props.tj).toFixed(1) : null;
+    const rows = [
+      ['SMP', props.smp], ['Dirección', props.dir || '-'],
+      ['Barrio', props.barrio || '-'], ['Distrito CUR', props.cpu || '-'],
+      ['Plano Límite', props.pl ? props.pl + 'm' : '-'],
+      ['Pisos permitidos', props.pisos || '-'],
+      ['FOT', props.fot || '-'],
+      ['Lote', props.area ? Math.round(props.area).toLocaleString('es-AR') + ' m²' : '-'],
+      ['Frente', props.fr ? props.fr + 'm' : '-'],
+      ['Fondo', props.fo ? props.fo + 'm' : '-'],
+      ['Tejido (real)', props.tj ? props.tj + 'm' : '-'],
+      ['Delta', delta ? delta + 'm' : '-'],
+    ].map(([l, v]) => `<tr><td style="color:rgba(255,255,255,.4)">${l}</td><td><strong>${v}</strong></td></tr>`).join('');
+    addReport(
+      `Parcela ${props.smp}`,
+      `<table>${rows}</table>`,
+    );
+  }
+
   // Fetch extra doc links
   fetch(`/api/parcela/${encodeURIComponent(props.smp)}`)
     .then(r => r.ok ? r.json() : null)
@@ -615,7 +637,12 @@ function setupFilters(barrios) {
 function selectBarrio(barrio) {
   $('barrioBtn').textContent = barrio || 'Todo CABA';
   $('barrioList').style.display = 'none';
-  Map.setBarrio(barrio).then(stats => { if (stats) updateStats(stats); });
+  Map.setBarrio(barrio).then(stats => {
+    if (stats) updateStats(stats);
+    if (barrio) {
+      addInfoMessage(`Mostrando ${stats?.count || ''} parcelas en ${barrio}`);
+    }
+  });
 }
 
 function applyFilters() {


### PR DESCRIPTION
## Summary

Map interactions now generate programmatic reports in the chat (zero LLM tokens):
- **Parcel click** → report card with SMP, dirección, PL, pisos, FOT, delta, etc.
- **Barrio selection** → info message "Mostrando N parcelas en BARRIO"

Only fires when chat is open. Uses `addReport()` and `addInfoMessage()` exported from chat.js.

## Test plan

- [ ] Open chat, click a parcel on map → report card appears in chat
- [ ] Report has all normative params (SMP, PL, pisos, delta, etc.)
- [ ] No LLM call made (check server logs)
- [ ] Select barrio → info message in chat
- [ ] With chat closed, click parcel → no chat interaction (card shows in left panel as before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)