### PR TITLE
Map click reports + no-cache headers

### DIFF
--- a/server.py
+++ b/server.py
@@ -704,16 +704,18 @@ class StaticFileFilterMiddleware(BaseHTTPMiddleware):
 
     async def dispatch(self, request: Request, call_next) -> StarletteResponse:
         path = request.url.path
-        # Only filter paths that would hit the catch-all static mount
         if path.startswith("/api/"):
             return await call_next(request)
         ext = Path(path).suffix.lower()
-        # Allow directory index (no extension) for html=True handling
         if ext and ext not in _SAFE_STATIC_EXTS:
             from starlette.responses import Response
 
             return Response(status_code=404)
-        return await call_next(request)
+        response = await call_next(request)
+        # Prevent browser caching of JS/CSS so deploys take effect immediately
+        if ext in (".js", ".css"):
+            response.headers["Cache-Control"] = "no-cache, must-revalidate"
+        return response
 
 
 app.add_middleware(StaticFileFilterMiddleware)


### PR DESCRIPTION
## Summary

- **Map click → chat report**: Parcel clicks generate a report card in chat with normative params (0 LLM tokens). Barrio selection adds info message.
- **No-cache headers**: JS/CSS files served with `Cache-Control: no-cache` to prevent stale modules after deploy.

## Test plan

- [ ] Open chat, click parcel on map → report card in chat
- [ ] Deploy new JS → browser loads fresh version (no hard refresh needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)