### PR TITLE
Collapse/expand reports + clean up history

### DIFF
--- a/chat.py
+++ b/chat.py
@@ -50,7 +50,6 @@ MAX_SQL_ROWS = 1000
 SQL_TIMEOUT_S = 10
 HTTP_TIMEOUT_S = 15
 SESSION_TTL_S = 30 * 60  # 30 minutes
-DOWNLOAD_DAILY_LIMIT_BYTES = 5 * 1024 * 1024  # 5 MB per user per day
 
 # ---------------------------------------------------------------------------
 # System prompt
@@ -197,71 +196,24 @@ _active_session_id: str | None = None
 
 @tool(
     "render_html",
-    "Mostrar una vista HTML al usuario (tabla, grafico, mapa, etc). "
-    "El HTML se renderiza en un iframe con tema oscuro y auto-resize.",
-    {"title": str, "html": str},
+    "Crear un reporte HTML para el usuario (tabla, grafico, mapa, etc). "
+    "Se renderiza en un iframe con tema oscuro y auto-resize. "
+    "Usar collapsed=true para archivos de descarga que no necesitan vista previa.",
+    {"title": str, "html": str, "collapsed": bool},
 )
 async def tool_render_html(args: dict[str, Any]) -> dict[str, Any]:
     """Wrap HTML in dark-theme template and queue for SSE stream."""
     title: str = args.get("title", "Vista")
     html: str = args.get("html", "")
-    logger.info("tool_render_html title=%s html_len=%d", title, len(html))
+    collapsed: bool = args.get("collapsed", False)
+    logger.info("tool_render_html title=%s html_len=%d collapsed=%s", title, len(html), collapsed)
     wrapped = _wrap_html_for_iframe(html)
     if _active_session_id:
-        _pending_renders[_active_session_id].append({"title": title, "html": wrapped})
+        _pending_renders[_active_session_id].append({
+            "title": title, "html": wrapped, "collapsed": collapsed,
+        })
     return _tool_text(
-        "Vista HTML renderizada correctamente. El usuario puede verla en el chat."
-    )
-
-
-# In-memory download byte counters: {user_id: {date_str: bytes_used}}
-_download_usage: dict[str, dict[str, int]] = defaultdict(lambda: defaultdict(int))
-
-
-@tool(
-    "create_download",
-    "Crear un archivo descargable para el usuario. Limite: 5 MB/dia por usuario. "
-    "Tipos comunes: text/csv, application/json, text/plain.",
-    {"filename": str, "content": str, "mime_type": str},
-)
-async def tool_create_download(args: dict[str, Any]) -> dict[str, Any]:
-    """Write content to a temp file and return a download URL."""
-    filename: str = args.get("filename", "archivo.txt")
-    content: str = args.get("content", "")
-    mime_type: str = args.get("mime_type", "text/plain")
-
-    # Sanitize filename
-    safe_name = Path(filename).name
-    if not safe_name:
-        safe_name = "archivo.txt"
-
-    content_bytes = content.encode("utf-8")
-
-    # Check daily limit (use a placeholder user_id — real tracking via session)
-    today = time.strftime("%Y-%m-%d")
-    user_key = "global"  # Simplified; could be per-session
-    used = _download_usage[user_key][today]
-    if used + len(content_bytes) > DOWNLOAD_DAILY_LIMIT_BYTES:
-        remaining = max(0, DOWNLOAD_DAILY_LIMIT_BYTES - used)
-        return _tool_error(
-            f"Limite diario de descargas excedido. "
-            f"Quedan {remaining} bytes de {DOWNLOAD_DAILY_LIMIT_BYTES}."
-        )
-
-    # Write to temp dir with UUID prefix
-    DOWNLOADS_DIR.mkdir(parents=True, exist_ok=True)
-    unique_name = f"{uuid.uuid4().hex[:12]}_{safe_name}"
-    file_path = DOWNLOADS_DIR / unique_name
-    file_path.write_bytes(content_bytes)
-
-    _download_usage[user_key][today] += len(content_bytes)
-
-    download_url = f"/api/downloads/{unique_name}"
-    return _tool_text(
-        json.dumps(
-            {"url": download_url, "filename": safe_name, "mime_type": mime_type},
-            ensure_ascii=False,
-        )
+        "Reporte creado correctamente. El usuario puede verlo y descargarlo."
     )
 
 
@@ -329,7 +281,7 @@ def _tool_error(message: str) -> dict[str, Any]:
 
 edificia_mcp = create_sdk_mcp_server(
     "edificia",
-    tools=[tool_sql, tool_schema, tool_http, tool_render_html, tool_create_download],
+    tools=[tool_sql, tool_schema, tool_http, tool_render_html],
 )
 
 
@@ -647,12 +599,6 @@ def _persist_entry(
 
 def cleanup_old_downloads(max_age_seconds: int = 3600) -> int:
     """Remove download files older than max_age_seconds. Returns count."""
-    # Prune stale date keys from download usage tracking
-    today = time.strftime("%Y-%m-%d")
-    stale_keys = [k for k in _download_usage if k != today]
-    for k in stale_keys:
-        del _download_usage[k]
-
     if not DOWNLOADS_DIR.exists():
         return 0
     now = time.time()

--- a/normativa/CLAUDE.md
+++ b/normativa/CLAUDE.md
@@ -138,7 +138,6 @@ Cuando uses `render_html`, tu HTML se muestra en un iframe dentro del chat:
 - **schema**: Solo si necesitas verificar un nombre de columna exacto. Normalmente
   no es necesario.
 - **http**: Para consultar APIs del GCBA en tiempo real (EPOK, CUR3D, USIG).
-- **render_html**: Para tablas, graficos o visualizaciones.
-- **create_download**: Para exportar datasets (CSV, JSON). Usar cuando el
-  usuario pide descargar o cuando hay demasiadas filas para una tabla.
+- **render_html**: Para tablas, graficos o visualizaciones. Usa `collapsed=true`
+  para archivos de descarga que no necesitan vista previa (ej. CSV grandes).
 - **Read/Grep/Glob**: Para leer archivos de normativa en este directorio.

--- a/static/js/chat.js
+++ b/static/js/chat.js
@@ -76,8 +76,7 @@ function _buildDOM() {
     <div id="chat-body">
       <div id="chat-history" style="display:none">
         <div id="history-tabs">
-          <button class="htab active" data-tab="sessions">Conversaciones</button>
-          <button class="htab" data-tab="files">Archivos</button>
+          <button class="htab active" data-tab="sessions">Historial</button>
         </div>
         <div id="history-list"></div>
       </div>
@@ -236,7 +235,11 @@ function _handleSSEEvent(event, updater) {
       updater.append(event.data);
       break;
     case 'artifact':
-      _renderReport(event.data.title, event.data.html);
+      if (event.data.collapsed) {
+        _renderCollapsedReport(event.data.title, event.data.html);
+      } else {
+        _renderReport(event.data.title, event.data.html);
+      }
       break;
     case 'error':
       _renderError(event.data);
@@ -424,6 +427,72 @@ function _renderReport(title, html) {
   _scrollToBottom();
 }
 
+function _renderCollapsedReport(title, html) {
+  const fmtSize = b => b > 1024 ? (b / 1024).toFixed(1) + ' KB' : b + ' B';
+  const wrapper = document.createElement('div');
+  wrapper.className = 'chat-collapsed-report';
+  wrapper.innerHTML = `
+    <div style="display:flex;align-items:center;gap:8px">
+      <span class="ccr-expand" style="cursor:pointer">▸</span>
+      <span style="font-size:12px;color:rgba(255,255,255,.7)">${_escapeHtml(title)}</span>
+      <span style="font-size:10px;color:rgba(255,255,255,.3)">${fmtSize(new Blob([html]).size)}</span>
+    </div>
+    <div style="display:flex;gap:4px;margin-left:auto">
+      <button class="art-dl-btn" data-fmt="html">↓ HTML</button>
+      <button class="art-dl-btn" data-fmt="pdf">↓ PDF</button>
+    </div>
+  `;
+  const expandBtn = wrapper.querySelector('.ccr-expand');
+  expandBtn.addEventListener('click', () => {
+    // Replace collapsed with full report
+    const parent = wrapper.parentNode;
+    const report = document.createElement('div');
+    report.className = 'chat-view';
+    const artId = 'art-' + Date.now();
+    report.innerHTML = `
+      <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:6px">
+        <div style="font-size:10px;letter-spacing:2px;text-transform:uppercase;color:rgba(255,255,255,.3)">${_escapeHtml(title)}</div>
+        <div style="display:flex;gap:4px">
+          <button class="art-dl-btn" data-fmt="html">↓ HTML</button>
+          <button class="art-dl-btn" data-fmt="pdf">↓ PDF</button>
+        </div>
+      </div>
+      <iframe id="${artId}" sandbox="allow-scripts allow-modals" srcdoc="${html.replace(/"/g, '&quot;')}" style="width:100%;min-height:60px;height:60px;border:1px solid rgba(255,255,255,.08);border-radius:8px;background:#0a0a0a;transition:height .2s"></iframe>
+    `;
+    report.querySelector('[data-fmt="html"]').addEventListener('click', () => {
+      const blob = new Blob([html], { type: 'text/html' });
+      const a = document.createElement('a');
+      a.href = URL.createObjectURL(blob);
+      a.download = title.replace(/[^a-zA-Z0-9áéíóúñ _-]/gi, '_').slice(0, 60) + '.html';
+      a.click();
+      URL.revokeObjectURL(a.href);
+    });
+    report.querySelector('[data-fmt="pdf"]').addEventListener('click', () => {
+      const iframe = document.getElementById(artId);
+      if (iframe?.contentWindow) iframe.contentWindow.print();
+    });
+    parent.replaceChild(report, wrapper);
+  });
+  // Download handlers on collapsed view
+  wrapper.querySelector('[data-fmt="html"]').addEventListener('click', () => {
+    const blob = new Blob([html], { type: 'text/html' });
+    const a = document.createElement('a');
+    a.href = URL.createObjectURL(blob);
+    a.download = title.replace(/[^a-zA-Z0-9áéíóúñ _-]/gi, '_').slice(0, 60) + '.html';
+    a.click();
+    URL.revokeObjectURL(a.href);
+  });
+  wrapper.querySelector('[data-fmt="pdf"]').addEventListener('click', () => {
+    expandBtn.click(); // expand first, then print
+    setTimeout(() => {
+      const iframe = wrapper.parentNode?.querySelector('iframe');
+      if (iframe?.contentWindow) iframe.contentWindow.print();
+    }, 1000);
+  });
+  _messagesEl.appendChild(wrapper);
+  _scrollToBottom();
+}
+
 function _renderError(message) {
   const el = document.createElement('div');
   el.className = 'chat-msg chat-msg-error';
@@ -453,11 +522,7 @@ async function _loadHistoryTab(tab) {
     if (!resp.ok) throw new Error(resp.statusText);
     const sessions = await resp.json();
 
-    if (tab === 'sessions') {
-      _renderSessionsList(list, sessions);
-    } else {
-      _renderFilesList(list, sessions);
-    }
+    _renderSessionsList(list, sessions);
   } catch {
     list.innerHTML = '<div style="color:#f87171;padding:16px;font-size:12px">Error cargando historial</div>';
   }
@@ -483,57 +548,13 @@ function _renderSessionsList(container, sessions) {
   });
 }
 
-function _renderFilesList(container, sessions) {
-  // Fetch all sessions to get artifacts
-  const filePromises = sessions.slice(0, 20).map(s =>
-    fetch(`/api/chat/sessions/${s.id}`).then(r => r.ok ? r.json() : null)
-  );
-  Promise.all(filePromises).then(results => {
-    const files = [];
-    for (const r of results) {
-      if (!r) continue;
-      for (const e of r.entries) {
-        if (e.kind === 'report') {
-          try {
-            const data = JSON.parse(e.content);
-            files.push({ title: data.title || 'Report', size: data.size || data.html?.length || 0, created_at: e.created_at, html: data.html });
-          } catch { /* skip */ }
-        }
-      }
-    }
-    if (!files.length) {
-      container.innerHTML = '<div style="color:rgba(255,255,255,.3);padding:16px;font-size:12px">Sin archivos</div>';
-      return;
-    }
-    const fmtSize = b => b > 1024 ? (b / 1024).toFixed(1) + ' KB' : b + ' B';
-    container.innerHTML = files.map((f, i) => `
-      <div class="hist-file" data-idx="${i}">
-        <div class="hist-preview">${_escapeHtml(f.title)}</div>
-        <div class="hist-meta">${fmtSize(f.size)}</div>
-      </div>
-    `).join('');
-    container.querySelectorAll('.hist-file').forEach(el => {
-      const f = files[parseInt(el.dataset.idx)];
-      if (f.html) {
-        el.addEventListener('click', () => {
-          _historyOpen = false;
-          _historyPanel.style.display = 'none';
-          _renderReport(f.title, f.html);
-        });
-      }
-    });
-  });
-}
-
 async function _loadSession(sessionId) {
   try {
     const resp = await fetch(`/api/chat/sessions/${sessionId}`);
     if (!resp.ok) return;
     const data = await resp.json();
 
-    // Close history, show entries read-only
-    _historyOpen = false;
-    _historyPanel.style.display = 'none';
+    // Show entries read-only (keep history open)
     _messagesEl.innerHTML = '';
 
     for (const entry of data.entries) {
@@ -783,6 +804,16 @@ function _applyStyles() {
     }
 
     .chat-view { margin: 4px 0; }
+    .chat-collapsed-report {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 8px 12px;
+      background: rgba(255,255,255,.03);
+      border: 1px solid rgba(255,255,255,.06);
+      border-radius: 8px;
+      margin: 4px 0;
+    }
 
     .chat-parcel-card {
       background: rgba(255,255,255,.04);


### PR DESCRIPTION
History stays open on session select. render_html gains collapsed param. create_download tool removed — every report is downloadable.