### PR TITLE
User plans: model access, credits, usage tracking

### DIFF
--- a/auth.py
+++ b/auth.py
@@ -42,9 +42,29 @@ GOOGLE_AUTH_URL = "https://accounts.google.com/o/oauth2/v2/auth"
 GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token"
 GOOGLE_USERINFO_URL = "https://www.googleapis.com/oauth2/v2/userinfo"
 
+# --- Plan tiers ---
+
+PLAN_DEFAULTS: dict[str, dict[str, Any]] = {
+    "free": {
+        "usd_mes_max": 0.02,
+        "modelos_habilitados": '["haiku"]',
+        "mb_mes_max": 1,
+    },
+    "pro": {
+        "usd_mes_max": 5.0,
+        "modelos_habilitados": '["haiku","sonnet","opus"]',
+        "mb_mes_max": 5,
+    },
+    "enterprise": {
+        "usd_mes_max": 999,
+        "modelos_habilitados": '["haiku","sonnet","opus"]',
+        "mb_mes_max": 999,
+    },
+}
+
 
 def init_users_table() -> None:
-    """Create users table if it doesn't exist, seed whitelisted users."""
+    """Create users table, migrate columns, seed users."""
     conn = sqlite3.connect(str(DB_PATH), timeout=20)
     conn.execute("""
         CREATE TABLE IF NOT EXISTS users (
@@ -60,20 +80,116 @@ def init_users_table() -> None:
             created_at REAL DEFAULT (strftime('%s', 'now'))
         )
     """)
-    # Add acceso_hasta column if missing (migration)
-    cols = [r[1] for r in conn.execute("PRAGMA table_info(users)").fetchall()]
-    if "acceso_hasta" not in cols:
-        conn.execute("ALTER TABLE users ADD COLUMN acceso_hasta TEXT")
-    # Seed whitelisted users
-    for email in ("karendmarini@gmail.com", "juanwisznia@gmail.com"):
-        existing = conn.execute("SELECT id FROM users WHERE email = ?", (email,)).fetchone()
-        if not existing:
-            conn.execute(
-                "INSERT INTO users (email, activo, acceso_hasta) VALUES (?, 1, '2099-12-31')",
-                (email,),
-            )
-        else:
-            conn.execute("UPDATE users SET activo = 1, acceso_hasta = '2099-12-31' WHERE email = ?", (email,))
+    # Migrate: add columns if missing
+    for col, default in [
+        ("acceso_hasta TEXT", None),
+        ("creditos_usd REAL", "0"),
+        ("modelos_habilitados TEXT", "'[\"haiku\"]'"),
+        ("mb_mes_max REAL", "1"),
+        ("usd_mes_max REAL", "0.02"),
+    ]:
+        try:
+            stmt = f"ALTER TABLE users ADD COLUMN {col}"
+            if default is not None:
+                stmt += f" DEFAULT {default}"
+            conn.execute(stmt)
+        except sqlite3.OperationalError:
+            pass
+
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS user_usage (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INTEGER NOT NULL,
+            month TEXT NOT NULL,
+            tokens_in INTEGER DEFAULT 0,
+            tokens_out INTEGER DEFAULT 0,
+            usd_used REAL DEFAULT 0,
+            mb_used REAL DEFAULT 0,
+            UNIQUE(user_id, month),
+            FOREIGN KEY (user_id) REFERENCES users(id)
+        )
+    """)
+
+    # Seed users
+    _upsert_seed(conn, "juanwisznia@gmail.com", "enterprise")
+    _upsert_seed(conn, "karendmarini@gmail.com", "pro")
+    conn.commit()
+    conn.close()
+
+
+def _upsert_seed(conn: sqlite3.Connection, email: str, plan: str) -> None:
+    defaults = PLAN_DEFAULTS[plan]
+    existing = conn.execute("SELECT id FROM users WHERE email = ?", (email,)).fetchone()
+    if not existing:
+        conn.execute(
+            "INSERT INTO users (email, activo, plan, acceso_hasta, modelos_habilitados, usd_mes_max, mb_mes_max) "
+            "VALUES (?, 1, ?, '2099-12-31', ?, ?, ?)",
+            (email, plan, defaults["modelos_habilitados"], defaults["usd_mes_max"], defaults["mb_mes_max"]),
+        )
+    else:
+        conn.execute(
+            "UPDATE users SET activo=1, plan=?, acceso_hasta='2099-12-31', "
+            "modelos_habilitados=?, usd_mes_max=?, mb_mes_max=? WHERE email=?",
+            (plan, defaults["modelos_habilitados"], defaults["usd_mes_max"], defaults["mb_mes_max"], email),
+        )
+
+
+def upsert_user(
+    email: str,
+    acceso_hasta: str,
+    plan: str = "free",
+    nombre: str = "",
+    creditos_usd: float | None = None,
+    modelos_habilitados: list[str] | None = None,
+    mb_mes_max: float | None = None,
+    usd_mes_max: float | None = None,
+) -> dict[str, Any]:
+    """Create or update a user. Custom values override plan defaults."""
+    defaults = PLAN_DEFAULTS.get(plan, PLAN_DEFAULTS["free"])
+    modelos = json.dumps(modelos_habilitados) if modelos_habilitados else defaults["modelos_habilitados"]
+    usd_max = usd_mes_max if usd_mes_max is not None else defaults["usd_mes_max"]
+    mb_max = mb_mes_max if mb_mes_max is not None else defaults["mb_mes_max"]
+    cred = creditos_usd if creditos_usd is not None else usd_max
+
+    conn = sqlite3.connect(str(DB_PATH), timeout=20)
+    conn.row_factory = sqlite3.Row
+    existing = conn.execute("SELECT id FROM users WHERE email = ?", (email,)).fetchone()
+    if existing:
+        conn.execute(
+            "UPDATE users SET activo=1, plan=?, nombre=?, acceso_hasta=?, "
+            "creditos_usd=?, modelos_habilitados=?, usd_mes_max=?, mb_mes_max=? WHERE email=?",
+            (plan, nombre, acceso_hasta, cred, modelos, usd_max, mb_max, email),
+        )
+    else:
+        conn.execute(
+            "INSERT INTO users (email, nombre, activo, plan, acceso_hasta, creditos_usd, "
+            "modelos_habilitados, usd_mes_max, mb_mes_max) VALUES (?,?,1,?,?,?,?,?,?)",
+            (email, nombre, plan, acceso_hasta, cred, modelos, usd_max, mb_max),
+        )
+    conn.commit()
+    row = conn.execute("SELECT * FROM users WHERE email = ?", (email,)).fetchone()
+    conn.close()
+    return dict(row)
+
+
+def track_usage(
+    user_id: int, tokens_in: int, tokens_out: int, usd_cost: float,
+) -> None:
+    """Record token usage for the current month and decrement credits."""
+    month = time.strftime("%Y-%m")
+    conn = sqlite3.connect(str(DB_PATH), timeout=20)
+    conn.execute(
+        "INSERT INTO user_usage (user_id, month, tokens_in, tokens_out, usd_used) "
+        "VALUES (?, ?, ?, ?, ?) "
+        "ON CONFLICT(user_id, month) DO UPDATE SET "
+        "tokens_in = tokens_in + ?, tokens_out = tokens_out + ?, usd_used = usd_used + ?",
+        (user_id, month, tokens_in, tokens_out, usd_cost,
+         tokens_in, tokens_out, usd_cost),
+    )
+    conn.execute(
+        "UPDATE users SET creditos_usd = MAX(0, creditos_usd - ?) WHERE id = ?",
+        (usd_cost, user_id),
+    )
     conn.commit()
     conn.close()
 
@@ -117,11 +233,13 @@ def get_current_user(request: Request) -> dict[str, Any] | None:
     conn = sqlite3.connect(str(DB_PATH), timeout=20)
     conn.row_factory = sqlite3.Row
     row = conn.execute(
-        "SELECT id, email, nombre, activo, plan, acceso_hasta FROM users WHERE id = ?",
+        "SELECT id, email, nombre, activo, plan, acceso_hasta, "
+        "creditos_usd, modelos_habilitados, usd_mes_max, mb_mes_max "
+        "FROM users WHERE id = ?",
         (int(payload["sub"]),),
     ).fetchone()
-    conn.close()
     if not row:
+        conn.close()
         return None
     user = dict(row)
     # Check expiry
@@ -130,6 +248,15 @@ def get_current_user(request: Request) -> dict[str, Any] | None:
         if date.fromisoformat(user["acceso_hasta"]) < date.today():
             user["activo"] = 0
             user["expired"] = True
+    # Fetch current month usage
+    month = time.strftime("%Y-%m")
+    usage = conn.execute(
+        "SELECT usd_used, mb_used FROM user_usage WHERE user_id = ? AND month = ?",
+        (user["id"], month),
+    ).fetchone()
+    conn.close()
+    user["usd_used_this_month"] = usage["usd_used"] if usage else 0
+    user["mb_used_this_month"] = usage["mb_used"] if usage else 0
     return user
 
 

--- a/chat.py
+++ b/chat.py
@@ -52,6 +52,13 @@ SQL_TIMEOUT_S = 10
 HTTP_TIMEOUT_S = 15
 SESSION_TTL_S = 30 * 60  # 30 minutes
 
+# Approximate Anthropic API pricing (USD per token)
+MODEL_PRICING = {
+    "haiku": {"input": 0.25e-6, "output": 1.25e-6},
+    "sonnet": {"input": 3.0e-6, "output": 15.0e-6},
+    "opus": {"input": 15.0e-6, "output": 75.0e-6},
+}
+
 # ---------------------------------------------------------------------------
 # System prompt
 # ---------------------------------------------------------------------------
@@ -537,6 +544,14 @@ async def create_sse_stream(
         session_id[:8], total_input_tokens, total_output_tokens,
         artifact_count, elapsed,
     )
+
+    # Track usage and decrement credits
+    if user_id and (total_input_tokens or total_output_tokens):
+        pricing = MODEL_PRICING.get(model, MODEL_PRICING["haiku"])
+        usd_cost = (total_input_tokens * pricing["input"]
+                     + total_output_tokens * pricing["output"])
+        from auth import track_usage
+        track_usage(user_id, total_input_tokens, total_output_tokens, usd_cost)
 
     yield SSEEvent(
         "done",

--- a/server.py
+++ b/server.py
@@ -46,6 +46,8 @@ from auth import (
     handle_register,
     init_users_table,
     require_active_user,
+    track_usage,
+    upsert_user,
 )
 
 from starlette.middleware.base import BaseHTTPMiddleware
@@ -184,6 +186,54 @@ def auth_logout():
 @app.get("/api/auth/me")
 def auth_me(request: Request):
     return handle_me(request)
+
+
+@app.get("/api/auth/plan")
+def auth_plan(request: Request) -> dict[str, Any]:
+    """Return current user's plan info for frontend model selector."""
+    user = require_active_user(request)
+    return {
+        "plan": user.get("plan", "free"),
+        "modelos_habilitados": json.loads(user.get("modelos_habilitados") or '["haiku"]'),
+        "creditos_usd": user.get("creditos_usd", 0),
+        "usd_mes_max": user.get("usd_mes_max", 0.02),
+        "usd_used": user.get("usd_used_this_month", 0),
+        "mb_mes_max": user.get("mb_mes_max", 1),
+        "mb_used": user.get("mb_used_this_month", 0),
+        "acceso_hasta": user.get("acceso_hasta"),
+    }
+
+
+class UpsertUserRequest(BaseModel):
+    email: str
+    acceso_hasta: str
+    plan: str = "free"
+    nombre: str = ""
+    creditos_usd: float | None = None
+    modelos_habilitados: list[str] | None = None
+    mb_mes_max: float | None = None
+    usd_mes_max: float | None = None
+
+
+ADMIN_EMAILS = frozenset({"juanwisznia@gmail.com"})
+
+
+@app.post("/api/admin/users")
+def admin_upsert_user(body: UpsertUserRequest, request: Request) -> dict[str, Any]:
+    """Create or update a user. Enterprise-only."""
+    user = require_active_user(request)
+    if user["email"] not in ADMIN_EMAILS:
+        raise HTTPException(403, "Admin access required")
+    return upsert_user(
+        email=body.email,
+        acceso_hasta=body.acceso_hasta,
+        plan=body.plan,
+        nombre=body.nombre,
+        creditos_usd=body.creditos_usd,
+        modelos_habilitados=body.modelos_habilitados,
+        mb_mes_max=body.mb_mes_max,
+        usd_mes_max=body.usd_mes_max,
+    )
 
 
 class SearchResult(BaseModel):
@@ -618,6 +668,17 @@ async def chat_endpoint(request: Request) -> StreamingResponse:
             raise HTTPException(status_code=403, detail="Account not active")
 
     body = ChatRequest(**(await request.json()))
+
+    # Check model access and limits
+    if user:
+        allowed = json.loads(user.get("modelos_habilitados") or '["haiku"]')
+        if body.model not in allowed:
+            raise HTTPException(403, f"Modelo {body.model} no disponible en tu plan")
+        if user.get("usd_used_this_month", 0) >= (user.get("usd_mes_max") or 0.02):
+            raise HTTPException(403, "Límite mensual de uso alcanzado")
+        if (user.get("creditos_usd") or 0) <= 0:
+            raise HTTPException(403, "Créditos agotados")
+
     client = await sessions.get_or_create(body.session_id, body.model)
 
     return StreamingResponse(

--- a/static/js/chat.js
+++ b/static/js/chat.js
@@ -17,10 +17,11 @@
 // ── State ────────────────────────────────────────────────────────
 
 let _mode = 'hidden';
-let _model = 'sonnet';
+let _model = 'haiku';
 let _sessionId = crypto.randomUUID();
 let _streaming = false;
 let _abortController = null;
+let _userPlan = null;
 
 // ── DOM refs ─────────────────────────────────────────────────────
 
@@ -33,6 +34,7 @@ export function initChat() {
   _buildDOM();
   _bindKeys();
   _listenIframeResize();
+  _loadUserPlan();
 
   // Bind the static header toggle button
   const toggle = document.getElementById('chat-toggle');
@@ -62,8 +64,8 @@ function _buildDOM() {
         <span style="font-size:10px;letter-spacing:3px;text-transform:uppercase;color:rgba(255,255,255,.4)">EdificIA Chat</span>
         <select id="chat-model" style="background:rgba(255,255,255,.06);border:1px solid rgba(255,255,255,.1);
           border-radius:6px;color:#fff;font:inherit;font-size:11px;padding:4px 8px;cursor:pointer;outline:none">
-          <option value="haiku">Haiku</option>
-          <option value="sonnet" selected>Sonnet</option>
+          <option value="haiku" selected>Haiku</option>
+          <option value="sonnet">Sonnet</option>
           <option value="opus">Opus</option>
         </select>
       </div>
@@ -118,6 +120,33 @@ function _buildDOM() {
   });
 
   _applyStyles();
+}
+
+async function _loadUserPlan() {
+  try {
+    const r = await fetch('/api/auth/plan');
+    if (!r.ok) return;
+    _userPlan = await r.json();
+    _updateModelSelector();
+  } catch { /* not logged in or no auth */ }
+}
+
+function _updateModelSelector() {
+  const allowed = _userPlan?.modelos_habilitados || ['haiku'];
+  const models = [
+    { id: 'haiku', label: 'Haiku' },
+    { id: 'sonnet', label: 'Sonnet' },
+    { id: 'opus', label: 'Opus' },
+  ];
+  _modelSelect.innerHTML = models.map(m => {
+    const locked = !allowed.includes(m.id);
+    const title = locked ? `Comunicate con el equipo de EdificIA para tener acceso a ${m.label}` : '';
+    return `<option value="${m.id}" ${locked ? 'disabled' : ''} ${title ? `title="${title}"` : ''}>${locked ? '\u{1F512} ' : ''}${m.label}</option>`;
+  }).join('');
+  if (!allowed.includes(_model)) {
+    _model = allowed[0] || 'haiku';
+  }
+  _modelSelect.value = _model;
 }
 
 function _bindKeys() {


### PR DESCRIPTION
## Summary

- **Plan tiers**: free ($0.02/mo, haiku only, 1MB), pro ($5/mo, all models, 5MB), enterprise (unlimited)
- **Model access**: Per-user whitelist enforced server-side. Frontend shows 🔒 on locked models with tooltip
- **Usage tracking**: `user_usage` table tracks tokens/USD/MB per month. Credits decremented per turn
- **Admin API**: `POST /api/admin/users` to create/update users with custom plan params
- **Plan API**: `GET /api/auth/plan` returns user's limits for frontend
- **Seed data**: juanwisznia = enterprise, karendmarini = pro, new users = free

## Test plan

- [ ] Server starts (migration adds new columns)
- [ ] Free user can only select Haiku (Sonnet/Opus locked with 🔒)
- [ ] Pro user can select all models
- [ ] Chat with locked model → 403
- [ ] Usage tracked in user_usage table after chat
- [ ] POST /api/admin/users creates user with custom params

🤖 Generated with [Claude Code](https://claude.com/claude-code)