### PR TITLE
Pro plan: haiku only

### DIFF
--- a/auth.py
+++ b/auth.py
@@ -52,7 +52,7 @@ PLAN_DEFAULTS: dict[str, dict[str, Any]] = {
     },
     "pro": {
         "usd_mes_max": 5.0,
-        "modelos_habilitados": '["haiku","sonnet","opus"]',
+        "modelos_habilitados": '["haiku"]',
         "mb_mes_max": 5,
     },
     "enterprise": {


### PR DESCRIPTION
Pro tier now only has haiku. Sonnet/opus locked behind enterprise.