### PR TITLE
feat: módulo Full Report — informe completo a pantalla completa

### DIFF
--- a/index.html
+++ b/index.html
@@ -230,7 +230,76 @@
         .av2{stroke:#fff;stroke-width:1.1;fill:none;opacity:.45}
         .lb{fill:rgba(255,255,255,.3);font-family:'Inter',sans-serif;font-size:7.5px;letter-spacing:2.5px;text-transform:uppercase}
         .lb2{fill:rgba(255,255,255,.18);font-family:'Inter',sans-serif;font-size:5.5px;letter-spacing:1.5px}
-      </style></defs>
+  
+    /* ── FULL REPORT MODAL ─────────────────────────────────── */
+    .btn-full-report{
+      display:none;width:100%;margin-top:10px;padding:12px;
+      background:transparent;color:var(--accent);
+      border:1px solid var(--accent);border-radius:var(--r);
+      font:inherit;font-size:10px;font-weight:500;letter-spacing:2.5px;
+      text-transform:uppercase;cursor:pointer;transition:background .2s,color .2s;
+    }
+    .btn-full-report:hover{background:var(--accent);color:#000}
+    .btn-full-report.visible{display:block}
+
+    #full-report-modal{
+      display:none;position:fixed;inset:0;
+      width:100vw;height:100vh;background:#000;
+      z-index:9999;overflow-y:auto;
+    }
+    #full-report-modal.open{display:block}
+    .frm-inner{
+      max-width:720px;margin:0 auto;padding:60px 32px 80px;
+    }
+    .frm-close{
+      position:fixed;top:20px;right:24px;
+      font-size:28px;color:rgba(255,255,255,.4);cursor:pointer;
+      background:none;border:none;line-height:1;transition:color .2s;z-index:10000;
+    }
+    .frm-close:hover{color:#fff}
+    .frm-eyebrow{
+      font-size:9px;letter-spacing:4px;text-transform:uppercase;
+      color:rgba(255,255,255,.35);margin-bottom:10px;
+    }
+    .frm-address{
+      font-size:clamp(22px,4vw,38px);font-weight:200;
+      color:#fff;letter-spacing:-.5px;line-height:1.15;margin-bottom:4px;
+    }
+    .frm-badge{
+      display:inline-block;font-size:9px;font-weight:600;letter-spacing:2px;
+      text-transform:uppercase;padding:5px 14px;border-radius:100px;
+      background:rgba(200,169,110,.12);color:#C8A96E;
+      border:1px solid rgba(200,169,110,.25);margin-bottom:40px;
+    }
+    .frm-divider{border:none;border-top:1px solid rgba(255,255,255,.08);margin:32px 0}
+    .frm-section-label{
+      font-size:9px;letter-spacing:3px;text-transform:uppercase;
+      color:rgba(255,255,255,.35);margin-bottom:20px;
+    }
+    .frm-hero{
+      background:rgba(200,169,110,.06);border:1px solid rgba(200,169,110,.2);
+      border-radius:8px;padding:28px 32px;margin-bottom:24px;text-align:center;
+    }
+    .frm-hero-label{font-size:10px;letter-spacing:2px;text-transform:uppercase;color:#C8A96E;margin-bottom:8px}
+    .frm-hero-val{font-size:clamp(48px,8vw,72px);font-weight:200;color:#fff;line-height:1;letter-spacing:-2px}
+    .frm-hero-unit{font-size:14px;font-weight:300;color:rgba(255,255,255,.5);margin-top:4px}
+    .frm-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:1px;
+      background:rgba(255,255,255,.07);border:1px solid rgba(255,255,255,.07);
+      border-radius:6px;overflow:hidden;margin-bottom:16px}
+    .frm-cell{background:#0d0d0d;padding:20px 22px}
+    .frm-cell-label{font-size:8px;letter-spacing:2.5px;text-transform:uppercase;
+      color:rgba(255,255,255,.35);margin-bottom:8px}
+    .frm-cell-val{font-size:26px;font-weight:300;color:#fff;line-height:1}
+    .frm-cell-val.accent{color:#C8A96E}
+    .frm-cell-unit{font-size:10px;color:rgba(255,255,255,.35);margin-top:4px}
+    .frm-footer{margin-top:48px;padding-top:20px;border-top:1px solid rgba(255,255,255,.08);
+      font-size:9px;letter-spacing:2px;text-transform:uppercase;
+      color:rgba(255,255,255,.2);text-align:center}
+    @media(max-width:600px){
+      .frm-inner{padding:40px 20px 60px}
+      .frm-close{top:14px;right:16px}
+    }
+    </style></defs>
       <path class="av2" d="M80,50 L500,38 L545,100 L560,240 L540,380 L510,490 L455,590 L360,650 L240,658 L140,620 L80,550 L45,420 L35,260 L55,130 Z" opacity=".45"/>
       <path d="M500,38 L545,100 L560,240 L540,380 L510,490 L455,590" stroke="#fff" stroke-width=".3" fill="none" opacity=".1" stroke-dasharray="5,4"/>
       <path class="av" d="M80,50 L55,130 L45,260 L50,380 L80,500 L140,580"/>
@@ -399,6 +468,7 @@
       <div><div id="res-addr">—</div><div id="res-coords"></div></div>
       <div class="dbadge unknown" id="res-badge">—</div>
     </div>
+    <button class="btn-full-report" id="open-full-report">Ver informe completo ↗</button>
 
     <div id="aph-box"><strong>APH</strong> — Área de Protección Histórica.</div>
     <div id="u-box"><strong>U</strong></div>
@@ -472,5 +542,79 @@
   initApp();
   initChat();
 </script>
+
+  <!-- FULL REPORT MODAL -->
+  <div id="full-report-modal">
+    <button class="frm-close" id="close-full-report" title="Cerrar">&times;</button>
+    <div class="frm-inner">
+      <div class="frm-eyebrow">EdificIA · Estudio de Factibilidad Preliminar</div>
+      <div class="frm-address" id="frm-address">—</div>
+      <div class="frm-badge" id="frm-badge">—</div>
+
+      <div class="frm-section-label">Superficie Vendible Estimada</div>
+      <div class="frm-hero">
+        <div class="frm-hero-label">Total Vendible</div>
+        <div class="frm-hero-val" id="frm-total-vend">—</div>
+        <div class="frm-hero-unit">m²</div>
+      </div>
+
+      <div class="frm-grid">
+        <div class="frm-cell">
+          <div class="frm-cell-label">Cubierto</div>
+          <div class="frm-cell-val accent" id="frm-vend-cub">—</div>
+          <div class="frm-cell-unit" id="frm-eficiencia">m²</div>
+        </div>
+        <div class="frm-cell">
+          <div class="frm-cell-label">Balcones (semicubierto)</div>
+          <div class="frm-cell-val" id="frm-balcones">—</div>
+          <div class="frm-cell-unit">m²</div>
+        </div>
+        <div class="frm-cell">
+          <div class="frm-cell-label">Volumen Edificable</div>
+          <div class="frm-cell-val" id="frm-volumen">—</div>
+          <div class="frm-cell-unit">m²</div>
+        </div>
+      </div>
+
+      <hr class="frm-divider">
+      <div class="frm-section-label">Parámetros Normativos</div>
+
+      <div class="frm-grid">
+        <div class="frm-cell">
+          <div class="frm-cell-label">Distrito CUR</div>
+          <div class="frm-cell-val sm" id="frm-distrito" style="font-size:18px">—</div>
+        </div>
+        <div class="frm-cell">
+          <div class="frm-cell-label">Altura Dominante</div>
+          <div class="frm-cell-val" id="frm-altura">—</div>
+          <div class="frm-cell-unit">metros</div>
+        </div>
+        <div class="frm-cell">
+          <div class="frm-cell-label">Plano Límite</div>
+          <div class="frm-cell-val accent" id="frm-plano">—</div>
+          <div class="frm-cell-unit">metros</div>
+        </div>
+        <div class="frm-cell">
+          <div class="frm-cell-label">Pisos Estimados</div>
+          <div class="frm-cell-val" id="frm-pisos">—</div>
+        </div>
+        <div class="frm-cell">
+          <div class="frm-cell-label">Superficie Lote</div>
+          <div class="frm-cell-val" id="frm-lote">—</div>
+          <div class="frm-cell-unit">m²</div>
+        </div>
+        <div class="frm-cell">
+          <div class="frm-cell-label">Pisada Edificable</div>
+          <div class="frm-cell-val" id="frm-pisada">—</div>
+          <div class="frm-cell-unit">m²</div>
+        </div>
+      </div>
+
+      <div class="frm-footer">
+        Estudio de factibilidad preliminar · EdificIA · CUR Ley 6099/2018 · Datos orientativos
+      </div>
+    </div>
+  </div>
+
 </body>
 </html>

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -641,3 +641,84 @@ function debounce(fn, ms) {
 
 window.recalculate = recalculate;
 window.recalcFinancials = recalcFinancials;
+
+
+// ── FULL REPORT MODAL ────────────────────────────────────────────
+
+function openFullReport() {
+  const modal = document.getElementById('full-report-modal');
+  if (!modal) return;
+
+  // Leer valores ya renderizados en el panel lateral (no recalcula)
+  const get = id => document.getElementById(id)?.textContent?.trim() || '—';
+  const getVal = id => document.getElementById(id)?.value?.trim() || '—';
+
+  // Dirección y badge
+  document.getElementById('frm-address').textContent = get('res-addr');
+  document.getElementById('frm-badge').textContent    = get('res-badge');
+
+  // Normativa
+  document.getElementById('frm-altura').textContent   = get('res-alt');
+  document.getElementById('frm-plano').textContent    = get('res-plano');
+  document.getElementById('frm-pisos').textContent    = get('res-pis');
+  document.getElementById('frm-distrito').textContent = get('res-dis');
+
+  // Calculadora
+  document.getElementById('frm-lote').textContent     = getVal('c-sup');
+  document.getElementById('frm-pisada').textContent   = getVal('c-pb');
+  document.getElementById('frm-volumen').textContent  = get('c-edif');
+
+  // Vendibles — parsear el desglose del c-vend
+  const cvendEl = document.getElementById('c-vend');
+  if (cvendEl) {
+    const cubEl  = cvendEl.querySelector('[data-frm="cub"]');
+    const balcEl = cvendEl.querySelector('[data-frm="balc"]');
+    const totEl  = cvendEl.querySelector('[data-frm="total"]');
+    const efEl   = cvendEl.querySelector('[data-frm="ef"]');
+    document.getElementById('frm-vend-cub').textContent    = cubEl  ? cubEl.textContent  : get('c-vend');
+    document.getElementById('frm-balcones').textContent    = balcEl ? balcEl.textContent : '—';
+    document.getElementById('frm-total-vend').textContent  = totEl  ? totEl.textContent  : get('c-vend');
+    document.getElementById('frm-eficiencia').textContent  = efEl   ? 'Eficiencia: ' + efEl.textContent : 'm²';
+  }
+
+  modal.classList.add('open');
+  document.body.style.overflow = 'hidden';
+}
+
+function closeFullReport() {
+  const modal = document.getElementById('full-report-modal');
+  if (modal) modal.classList.remove('open');
+  document.body.style.overflow = '';
+}
+
+// Mostrar/ocultar botón junto con el panel de resultados
+const _origShow = typeof showParcelDetail === 'function' ? showParcelDetail : null;
+
+document.addEventListener('DOMContentLoaded', () => {
+  // Botón abrir
+  document.getElementById('open-full-report')
+    ?.addEventListener('click', openFullReport);
+  // Botón cerrar
+  document.getElementById('close-full-report')
+    ?.addEventListener('click', closeFullReport);
+  // Cerrar con Escape
+  document.addEventListener('keydown', e => {
+    if (e.key === 'Escape') closeFullReport();
+  });
+});
+
+// Mostrar el botón cuando los resultados estén visibles
+const _resultsObserver = new MutationObserver(() => {
+  const res = document.getElementById('results');
+  const btn = document.getElementById('open-full-report');
+  if (!res || !btn) return;
+  if (res.classList.contains('on')) {
+    btn.classList.add('visible');
+  } else {
+    btn.classList.remove('visible');
+  }
+});
+document.addEventListener('DOMContentLoaded', () => {
+  const res = document.getElementById('results');
+  if (res) _resultsObserver.observe(res, { attributes: true, attributeFilter: ['class'] });
+});


### PR DESCRIPTION
## Qué agrega este PR

Un botón **"Ver informe completo ↗"** que aparece en el panel de resultados después de una búsqueda exitosa. Al clickearlo abre un overlay a pantalla completa con todos los datos en grande y formato arquitectónico.

## Archivos modificados

- `index.html` — CSS del modal, botón en panel de resultados, HTML del modal al final del body
- `static/js/app.js` — función `openFullReport()`, `closeFullReport()`, MutationObserver para mostrar/ocultar el botón, event listeners

## Qué NO se toca

- `static/js/map.js` — sin cambios
- `static/js/chat.js` — sin cambios
- Funciones de cálculo (`recalculate`, `sanitizeCUR`, etc.) — sin cambios
- IDs de inputs existentes — sin cambios

## Comportamiento

- El botón aparece **solo cuando hay resultados** (observer en `class` del div `#results`)
- Click en botón → modal a pantalla completa con datos copiados del panel lateral (no recalcula)
- Cierre: botón ×, tecla Escape
- Responsive: `overflow-y: auto` en mobile

## Contenido del informe

1. Dirección + badge de distrito
2. **Total vendible** en número grande (hero)
3. Desglose: cubierto + balcones + eficiencia
4. Grid normativa: distrito, altura, plano límite, pisos, lote, pisada
5. Nota al pie: "Estudio de factibilidad preliminar · EdificIA"

## Estética

Fondo `#000`, tipografía blanca Inter 200, acento dorado `#C8A96E` en valores clave.

cc @juanwisz para revisión