### PR TITLE
feat: rediseño editorial Full Report Modal — layout 3 secciones

### DIFF
--- a/index.html
+++ b/index.html
@@ -246,58 +246,127 @@
       display:none;position:fixed;inset:0;
       width:100vw;height:100vh;background:#000;
       z-index:9999;overflow-y:auto;
+      font-family:'Inter',system-ui,sans-serif;
+      -webkit-font-smoothing:antialiased;
     }
-    #full-report-modal.open{display:block}
-    .frm-inner{
-      max-width:720px;margin:0 auto;padding:60px 32px 80px;
-    }
+    #full-report-modal.open{display:flex;flex-direction:column}
+
+    /* Botón cierre */
     .frm-close{
-      position:fixed;top:20px;right:24px;
-      font-size:28px;color:rgba(255,255,255,.4);cursor:pointer;
-      background:none;border:none;line-height:1;transition:color .2s;z-index:10000;
+      position:fixed;top:28px;right:32px;
+      font-size:20px;font-weight:200;color:#C8A96E;
+      background:none;border:none;cursor:pointer;
+      letter-spacing:0;line-height:1;z-index:10000;
+      transition:opacity .2s;opacity:.7;
     }
-    .frm-close:hover{color:#fff}
+    .frm-close:hover{opacity:1}
+
+    /* Layout principal: 5vw de padding, 3 secciones */
+    .frm-layout{
+      flex:1;
+      display:grid;
+      grid-template-rows:auto 1fr auto;
+      padding:5vw;
+      gap:4vw;
+      min-height:100vh;
+    }
+
+    /* SECCIÓN A: Dirección + Badge */
+    .frm-section-a{
+      display:flex;align-items:flex-start;justify-content:space-between;gap:24px;
+      border-bottom:1px solid rgba(255,255,255,.08);
+      padding-bottom:4vw;
+    }
     .frm-eyebrow{
       font-size:9px;letter-spacing:4px;text-transform:uppercase;
-      color:rgba(255,255,255,.35);margin-bottom:10px;
+      color:rgba(255,255,255,.28);margin-bottom:12px;
     }
-    .frm-address{
-      font-size:clamp(22px,4vw,38px);font-weight:200;
-      color:#fff;letter-spacing:-.5px;line-height:1.15;margin-bottom:4px;
+    #frm-address{
+      font-size:clamp(1.8rem,3.5vw,3.5rem);font-weight:200;
+      color:#fff;letter-spacing:.05em;text-transform:uppercase;
+      line-height:1.1;
     }
-    .frm-badge{
-      display:inline-block;font-size:9px;font-weight:600;letter-spacing:2px;
-      text-transform:uppercase;padding:5px 14px;border-radius:100px;
-      background:rgba(200,169,110,.12);color:#C8A96E;
-      border:1px solid rgba(200,169,110,.25);margin-bottom:40px;
+    #frm-badge{
+      flex-shrink:0;margin-top:4px;
+      font-size:9px;font-weight:600;letter-spacing:2.5px;text-transform:uppercase;
+      padding:7px 18px;border-radius:100px;
+      background:rgba(200,169,110,.1);color:#C8A96E;
+      border:1px solid rgba(200,169,110,.3);white-space:nowrap;
     }
-    .frm-divider{border:none;border-top:1px solid rgba(255,255,255,.08);margin:32px 0}
-    .frm-section-label{
-      font-size:9px;letter-spacing:3px;text-transform:uppercase;
-      color:rgba(255,255,255,.35);margin-bottom:20px;
+
+    /* SECCIÓN B: Total vendible — número principal */
+    .frm-section-b{
+      display:flex;flex-direction:column;justify-content:center;
+      gap:8px;
     }
-    .frm-hero{
-      background:rgba(200,169,110,.06);border:1px solid rgba(200,169,110,.2);
-      border-radius:8px;padding:28px 32px;margin-bottom:24px;text-align:center;
+    .frm-main-label{
+      font-size:9px;letter-spacing:4px;text-transform:uppercase;
+      color:#C8A96E;
     }
-    .frm-hero-label{font-size:10px;letter-spacing:2px;text-transform:uppercase;color:#C8A96E;margin-bottom:8px}
-    .frm-hero-val{font-size:clamp(48px,8vw,72px);font-weight:200;color:#fff;line-height:1;letter-spacing:-2px}
-    .frm-hero-unit{font-size:14px;font-weight:300;color:rgba(255,255,255,.5);margin-top:4px}
-    .frm-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:1px;
-      background:rgba(255,255,255,.07);border:1px solid rgba(255,255,255,.07);
-      border-radius:6px;overflow:hidden;margin-bottom:16px}
-    .frm-cell{background:#0d0d0d;padding:20px 22px}
-    .frm-cell-label{font-size:8px;letter-spacing:2.5px;text-transform:uppercase;
-      color:rgba(255,255,255,.35);margin-bottom:8px}
-    .frm-cell-val{font-size:26px;font-weight:300;color:#fff;line-height:1}
-    .frm-cell-val.accent{color:#C8A96E}
-    .frm-cell-unit{font-size:10px;color:rgba(255,255,255,.35);margin-top:4px}
-    .frm-footer{margin-top:48px;padding-top:20px;border-top:1px solid rgba(255,255,255,.08);
-      font-size:9px;letter-spacing:2px;text-transform:uppercase;
-      color:rgba(255,255,255,.2);text-align:center}
+    .frm-main-val{
+      display:flex;align-items:baseline;gap:12px;
+      font-size:clamp(4rem,8vw,7rem);font-weight:200;
+      color:#fff;letter-spacing:-.02em;line-height:1;
+    }
+    .frm-main-val .unit{
+      font-size:clamp(1rem,1.8vw,1.6rem);font-weight:300;
+      color:rgba(255,255,255,.5);
+    }
+
+    /* Desglose: cubierto + balcones */
+    .frm-desglose{
+      display:flex;gap:5vw;margin-top:16px;
+      padding-top:16px;border-top:1px solid rgba(255,255,255,.06);
+    }
+    .frm-des-item{}
+    .frm-des-label{
+      font-size:8px;letter-spacing:3px;text-transform:uppercase;
+      color:#C8A96E;margin-bottom:6px;
+    }
+    .frm-des-val{
+      display:flex;align-items:baseline;gap:6px;
+      font-size:clamp(1.4rem,2.5vw,2.2rem);font-weight:200;color:#fff;
+    }
+    .frm-des-val .unit{font-size:.75rem;color:rgba(255,255,255,.4)}
+    .frm-des-sub{font-size:10px;color:rgba(255,255,255,.3);margin-top:3px}
+
+    /* SECCIÓN C: Grid parámetros */
+    .frm-section-c{
+      border-top:1px solid rgba(255,255,255,.08);
+      padding-top:4vw;
+    }
+    .frm-grid-label{
+      font-size:9px;letter-spacing:4px;text-transform:uppercase;
+      color:rgba(255,255,255,.28);margin-bottom:24px;
+    }
+    .frm-params-grid{
+      display:grid;
+      grid-template-columns:repeat(auto-fit,minmax(160px,1fr));
+      gap:3vw 4vw;
+    }
+    .frm-param{}
+    .frm-param-label{
+      font-size:8px;letter-spacing:3px;text-transform:uppercase;
+      color:#C8A96E;margin-bottom:8px;
+    }
+    .frm-param-val{
+      display:flex;align-items:baseline;gap:6px;
+      font-size:clamp(1.6rem,2.8vw,2.4rem);font-weight:200;color:#fff;line-height:1;
+    }
+    .frm-param-val .unit{font-size:.75rem;color:rgba(255,255,255,.35);font-weight:300}
+
+    /* Footer */
+    .frm-footer-note{
+      font-size:8px;letter-spacing:2.5px;text-transform:uppercase;
+      color:rgba(255,255,255,.15);text-align:right;
+      margin-top:4vw;padding-top:16px;
+      border-top:1px solid rgba(255,255,255,.05);
+    }
+
     @media(max-width:600px){
-      .frm-inner{padding:40px 20px 60px}
-      .frm-close{top:14px;right:16px}
+      .frm-section-a{flex-direction:column;gap:12px}
+      .frm-desglose{flex-direction:column;gap:20px}
+      .frm-params-grid{grid-template-columns:repeat(2,1fr)}
     }
     </style></defs>
       <path class="av2" d="M80,50 L500,38 L545,100 L560,240 L540,380 L510,490 L455,590 L360,650 L240,658 L140,620 L80,550 L45,420 L35,260 L55,130 Z" opacity=".45"/>
@@ -546,75 +615,103 @@
   <!-- FULL REPORT MODAL -->
   <div id="full-report-modal">
     <button class="frm-close" id="close-full-report" title="Cerrar">&times;</button>
-    <div class="frm-inner">
-      <div class="frm-eyebrow">EdificIA · Estudio de Factibilidad Preliminar</div>
-      <div class="frm-address" id="frm-address">—</div>
-      <div class="frm-badge" id="frm-badge">—</div>
 
-      <div class="frm-section-label">Superficie Vendible Estimada</div>
-      <div class="frm-hero">
-        <div class="frm-hero-label">Total Vendible</div>
-        <div class="frm-hero-val" id="frm-total-vend">—</div>
-        <div class="frm-hero-unit">m²</div>
+    <div class="frm-layout">
+
+      <!-- A: DIRECCIÓN + BADGE -->
+      <div class="frm-section-a">
+        <div>
+          <div class="frm-eyebrow">EdificIA · Estudio de Factibilidad Preliminar</div>
+          <div id="frm-address">—</div>
+        </div>
+        <div id="frm-badge">—</div>
       </div>
 
-      <div class="frm-grid">
-        <div class="frm-cell">
-          <div class="frm-cell-label">Cubierto</div>
-          <div class="frm-cell-val accent" id="frm-vend-cub">—</div>
-          <div class="frm-cell-unit" id="frm-eficiencia">m²</div>
+      <!-- B: TOTAL VENDIBLE -->
+      <div class="frm-section-b">
+        <div class="frm-main-label">Total Vendible Estimado</div>
+        <div class="frm-main-val">
+          <span id="frm-total-vend">—</span>
+          <span class="unit">m²</span>
         </div>
-        <div class="frm-cell">
-          <div class="frm-cell-label">Balcones (semicubierto)</div>
-          <div class="frm-cell-val" id="frm-balcones">—</div>
-          <div class="frm-cell-unit">m²</div>
-        </div>
-        <div class="frm-cell">
-          <div class="frm-cell-label">Volumen Edificable</div>
-          <div class="frm-cell-val" id="frm-volumen">—</div>
-          <div class="frm-cell-unit">m²</div>
-        </div>
-      </div>
 
-      <hr class="frm-divider">
-      <div class="frm-section-label">Parámetros Normativos</div>
-
-      <div class="frm-grid">
-        <div class="frm-cell">
-          <div class="frm-cell-label">Distrito CUR</div>
-          <div class="frm-cell-val sm" id="frm-distrito" style="font-size:18px">—</div>
-        </div>
-        <div class="frm-cell">
-          <div class="frm-cell-label">Altura Dominante</div>
-          <div class="frm-cell-val" id="frm-altura">—</div>
-          <div class="frm-cell-unit">metros</div>
-        </div>
-        <div class="frm-cell">
-          <div class="frm-cell-label">Plano Límite</div>
-          <div class="frm-cell-val accent" id="frm-plano">—</div>
-          <div class="frm-cell-unit">metros</div>
-        </div>
-        <div class="frm-cell">
-          <div class="frm-cell-label">Pisos Estimados</div>
-          <div class="frm-cell-val" id="frm-pisos">—</div>
-        </div>
-        <div class="frm-cell">
-          <div class="frm-cell-label">Superficie Lote</div>
-          <div class="frm-cell-val" id="frm-lote">—</div>
-          <div class="frm-cell-unit">m²</div>
-        </div>
-        <div class="frm-cell">
-          <div class="frm-cell-label">Pisada Edificable</div>
-          <div class="frm-cell-val" id="frm-pisada">—</div>
-          <div class="frm-cell-unit">m²</div>
+        <div class="frm-desglose">
+          <div class="frm-des-item">
+            <div class="frm-des-label">Vendible Cubierto</div>
+            <div class="frm-des-val">
+              <span id="frm-vend-cub">—</span>
+              <span class="unit">m²</span>
+            </div>
+            <div class="frm-des-sub" id="frm-eficiencia">Eficiencia</div>
+          </div>
+          <div class="frm-des-item">
+            <div class="frm-des-label">Balcones (Semicubierto)</div>
+            <div class="frm-des-val">
+              <span id="frm-balcones">—</span>
+              <span class="unit">m²</span>
+            </div>
+          </div>
+          <div class="frm-des-item">
+            <div class="frm-des-label">Volumen Edificable</div>
+            <div class="frm-des-val">
+              <span id="frm-volumen">—</span>
+              <span class="unit">m²</span>
+            </div>
+          </div>
         </div>
       </div>
 
-      <div class="frm-footer">
-        Estudio de factibilidad preliminar · EdificIA · CUR Ley 6099/2018 · Datos orientativos
+      <!-- C: GRID PARÁMETROS NORMATIVOS -->
+      <div class="frm-section-c">
+        <div class="frm-grid-label">Parámetros Normativos · CUR Ley 6099/2018</div>
+        <div class="frm-params-grid">
+          <div class="frm-param">
+            <div class="frm-param-label">Distrito CUR</div>
+            <div class="frm-param-val"><span id="frm-distrito">—</span></div>
+          </div>
+          <div class="frm-param">
+            <div class="frm-param-label">Altura Dominante</div>
+            <div class="frm-param-val">
+              <span id="frm-altura">—</span>
+              <span class="unit">m</span>
+            </div>
+          </div>
+          <div class="frm-param">
+            <div class="frm-param-label">Plano Límite</div>
+            <div class="frm-param-val">
+              <span id="frm-plano">—</span>
+              <span class="unit">m</span>
+            </div>
+          </div>
+          <div class="frm-param">
+            <div class="frm-param-label">Pisos Estimados</div>
+            <div class="frm-param-val"><span id="frm-pisos">—</span></div>
+          </div>
+          <div class="frm-param">
+            <div class="frm-param-label">Superficie Lote</div>
+            <div class="frm-param-val">
+              <span id="frm-lote">—</span>
+              <span class="unit">m²</span>
+            </div>
+          </div>
+          <div class="frm-param">
+            <div class="frm-param-label">Pisada Edificable</div>
+            <div class="frm-param-val">
+              <span id="frm-pisada">—</span>
+              <span class="unit">m²</span>
+            </div>
+          </div>
+        </div>
+
+        <div class="frm-footer-note">
+          Estudio de factibilidad preliminar · EdificIA · CUR Ley 6099/2018 · Datos orientativos
+        </div>
       </div>
+
     </div>
   </div>
+
+
 
 </body>
 </html>

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -649,37 +649,42 @@ function openFullReport() {
   const modal = document.getElementById('full-report-modal');
   if (!modal) return;
 
-  // Leer valores ya renderizados en el panel lateral (no recalcula)
-  const get = id => document.getElementById(id)?.textContent?.trim() || '—';
+  // Lee valores ya renderizados — NO recalcula nada
+  const get    = id => document.getElementById(id)?.textContent?.trim() || '—';
   const getVal = id => document.getElementById(id)?.value?.trim() || '—';
+  const set    = (id, val) => { const el = document.getElementById(id); if (el) el.textContent = val; };
 
-  // Dirección y badge
-  document.getElementById('frm-address').textContent = get('res-addr');
-  document.getElementById('frm-badge').textContent    = get('res-badge');
+  // A: Dirección + badge
+  set('frm-address', get('res-addr'));
+  set('frm-badge',   get('res-badge'));
 
-  // Normativa
-  document.getElementById('frm-altura').textContent   = get('res-alt');
-  document.getElementById('frm-plano').textContent    = get('res-plano');
-  document.getElementById('frm-pisos').textContent    = get('res-pis');
-  document.getElementById('frm-distrito').textContent = get('res-dis');
-
-  // Calculadora
-  document.getElementById('frm-lote').textContent     = getVal('c-sup');
-  document.getElementById('frm-pisada').textContent   = getVal('c-pb');
-  document.getElementById('frm-volumen').textContent  = get('c-edif');
-
-  // Vendibles — parsear el desglose del c-vend
+  // B: Total vendible — parsear el c-vend que tiene sub-divs
   const cvendEl = document.getElementById('c-vend');
   if (cvendEl) {
     const cubEl  = cvendEl.querySelector('[data-frm="cub"]');
     const balcEl = cvendEl.querySelector('[data-frm="balc"]');
     const totEl  = cvendEl.querySelector('[data-frm="total"]');
     const efEl   = cvendEl.querySelector('[data-frm="ef"]');
-    document.getElementById('frm-vend-cub').textContent    = cubEl  ? cubEl.textContent  : get('c-vend');
-    document.getElementById('frm-balcones').textContent    = balcEl ? balcEl.textContent : '—';
-    document.getElementById('frm-total-vend').textContent  = totEl  ? totEl.textContent  : get('c-vend');
-    document.getElementById('frm-eficiencia').textContent  = efEl   ? 'Eficiencia: ' + efEl.textContent : 'm²';
+    // Números limpios (sin "m²")
+    const clean  = str => str?.replace(/m²|m2/gi,'').trim() || '—';
+    set('frm-total-vend', clean(totEl  ? totEl.textContent  : cvendEl.textContent));
+    set('frm-vend-cub',   clean(cubEl  ? cubEl.textContent  : '—'));
+    set('frm-balcones',   clean(balcEl ? balcEl.textContent : '—'));
+    set('frm-eficiencia', efEl ? 'Eficiencia ' + efEl.textContent : '');
+  } else {
+    set('frm-total-vend', get('c-vend').replace(/m²|m2/gi,'').trim());
   }
+
+  // B: Volumen
+  set('frm-volumen', get('c-edif').replace(/m²|m2/gi,'').trim());
+
+  // C: Parámetros normativos
+  set('frm-altura',   get('res-alt'));
+  set('frm-plano',    get('res-plano'));
+  set('frm-pisos',    get('res-pis'));
+  set('frm-distrito', get('res-dis') || get('res-badge'));
+  set('frm-lote',     getVal('c-sup'));
+  set('frm-pisada',   getVal('c-pb'));
 
   modal.classList.add('open');
   document.body.style.overflow = 'hidden';


### PR DESCRIPTION
## Cambios

Rediseño completo del `#full-report-modal` para diseño editorial a pantalla completa.

### Layout
- 3 secciones en grilla: A (dirección + badge) / B (total vendible) / C (grid parámetros)
- Padding `5vw` uniforme, gaps amplios, sin tarjetas grises
- Tipografía sobre negro puro — sin fondos intermedios ni sombras

### Tipografía
- Dirección: `clamp(1.8rem, 3.5vw, 3.5rem)` weight 200, uppercase, `letter-spacing: .05em`
- Total vendible: `clamp(4rem, 8vw, 7rem)` weight 200 — número + m² en `<span>` separados
- Labels: dorado `#C8A96E`, `8-9px`, `letter-spacing: 3-4px`
- Parámetros: `clamp(1.6rem, 2.8vw, 2.4rem)` weight 200

### Otros
- Botón `×` fino, dorado, `opacity: .7` → `1` en hover
- Desglose cubierto + balcones en fila horizontal
- `openFullReport()` actualizada: usa `set()` helper, limpia `m²` de los números

### NO se tocó
- `map.js`, `chat.js`, lógica de cálculo, IDs de inputs

cc @juanwisz