### PR TITLE
Canvas renderer for Leaflet map

### DIFF
--- a/static/js/map.js
+++ b/static/js/map.js
@@ -78,6 +78,7 @@ export function initMap(containerId, callbacks = {}) {
   _map = L.map(containerId, {
     zoomControl: false,
     attributionControl: false,
+    preferCanvas: true,
   }).setView(CABA_CENTER, CABA_ZOOM);
 
   L.control.zoom({ position: 'topright' }).addTo(_map);


### PR DESCRIPTION
preferCanvas: true — renders 9500+ markers via Canvas instead of SVG DOM. Much faster on low-end devices.