### PR TITLE
Fix MP subscription + show k strikethrough

### DIFF
--- a/pricing.html
+++ b/pricing.html
@@ -106,7 +106,7 @@
   <!-- PRO -->
   <div class="plan featured">
     <div class="plan-name">Pro</div>
-    <div class="plan-price">$10.000 <small>ARS/mes</small></div>
+    <div class="plan-price"><s style="font-size:18px;color:rgba(255,255,255,.25);font-weight:300">$100.000</s> $10.000 <small>ARS/mes</small></div>
     <div class="plan-period">Suscripción mensual</div>
     <div class="plan-beta">90% OFF — precio beta</div>
     <ul class="features">

--- a/server.py
+++ b/server.py
@@ -322,13 +322,18 @@ async def subscribe(request: Request) -> dict[str, Any]:
     if user.get("plan") in ("pro", "enterprise"):
         return {"already_subscribed": True}
 
-    plan_id = await _get_or_create_mp_plan()
     async with httpx.AsyncClient() as client:
         resp = await client.post(
             "https://api.mercadopago.com/preapproval",
             headers={"Authorization": f"Bearer {MP_ACCESS_TOKEN}"},
             json={
-                "preapproval_plan_id": plan_id,
+                "reason": "EdificIA Pro — Beta",
+                "auto_recurring": {
+                    "frequency": 1,
+                    "frequency_type": "months",
+                    "transaction_amount": MP_PLAN_PRICE,
+                    "currency_id": "ARS",
+                },
                 "payer_email": user["email"],
                 "back_url": "https://edificia.website",
                 "status": "pending",


### PR DESCRIPTION
Use preapproval without plan (pending status, MP handles checkout). Show 100k tachado.