### PR TITLE
feat: branding V4 — logo E outline, DIFICIA, Karen Marini abajo

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,12 +25,13 @@
       display:flex;align-items:center;justify-content:space-between;
       position:fixed;top:0;left:0;right:0;z-index:200;
       background:color-mix(in srgb, var(--bg) 92%, transparent);backdrop-filter:blur(20px)}
-    .logo-wrap{display:flex;align-items:center;gap:12px}
-    .logo-mark{width:30px;height:30px;background:var(--accent);border:none;
-      display:flex;align-items:center;justify-content:center;font-size:12px;font-weight:700;letter-spacing:0;color:#000}
-    .logo-text-group{display:flex;flex-direction:column;gap:0px}
-    .branding-signature{font-size:7px;letter-spacing:4px;text-transform:uppercase;color:rgba(255,255,255,.32);font-weight:200;line-height:1;margin-bottom:6px;display:block}
-    .logo-name{font-size:2.2rem;font-weight:200;letter-spacing:6px;text-transform:uppercase;line-height:1;color:#fff}
+    .logo-wrap{display:flex;align-items:center;gap:14px;padding-left:4px}
+    .logo-mark{width:36px;height:36px;background:transparent;border:1.5px solid rgba(255,255,255,.85);
+      display:flex;align-items:center;justify-content:center;font-size:14px;font-weight:300;letter-spacing:0;color:#fff;flex-shrink:0}
+    .logo-text-group{display:flex;flex-direction:column;gap:3px}
+    .branding-signature{font-size:8px;text-transform:uppercase;color:rgba(255,255,255,.32);font-weight:200;line-height:1;
+      display:block;text-align:justify;text-align-last:justify;width:100%;margin-top:3px}
+    .logo-name{font-size:2.6rem;font-weight:200;letter-spacing:6px;text-transform:uppercase;line-height:1;color:#fff}
     .logo-name em{color:var(--accent);font-style:normal}
     .header-nav{display:flex;gap:24px}
     .header-nav a{font-size:9px;letter-spacing:2.5px;text-transform:uppercase;
@@ -214,8 +215,8 @@
   <div class="logo-wrap">
     <div class="logo-mark">E</div>
     <div class="logo-text-group">
+      <span class="logo-name">DIFIC<em>IA</em></span>
       <small class="branding-signature">KAREN MARINI</small>
-      <span class="logo-name">Edific<em>IA</em></span>
     </div>
   </div>
   <div class="header-nav">
@@ -679,11 +680,11 @@
     <div class="frm-body">
 
       <!-- LOGO INSTITUCIONAL -->
-      <div style="display:flex;align-items:center;gap:10px;margin-bottom:32px">
-        <div style="width:30px;height:30px;background:var(--accent);display:flex;align-items:center;justify-content:center;font-size:12px;font-weight:700;color:#000;flex-shrink:0">E</div>
-        <div style="display:flex;flex-direction:column;gap:3px">
-          <small style="font-size:7px;letter-spacing:4px;text-transform:uppercase;color:rgba(255,255,255,.32);font-weight:200">KAREN MARINI</small>
-          <span style="font-size:1.4rem;font-weight:200;letter-spacing:5px;text-transform:uppercase;color:#fff;line-height:1">Edific<em style="color:var(--accent);font-style:normal">IA</em></span>
+      <div style="display:flex;align-items:center;gap:14px;margin-bottom:40px">
+        <div style="width:44px;height:44px;border:1.5px solid rgba(255,255,255,.85);background:transparent;display:flex;align-items:center;justify-content:center;font-size:17px;font-weight:300;color:#fff;flex-shrink:0">E</div>
+        <div style="display:flex;flex-direction:column;gap:4px">
+          <span style="font-size:2rem;font-weight:200;letter-spacing:6px;text-transform:uppercase;color:#fff;line-height:1">DIFIC<em style="color:var(--accent);font-style:normal">IA</em></span>
+          <small style="font-size:9px;text-transform:uppercase;color:rgba(255,255,255,.32);font-weight:200;display:block;text-align:justify;text-align-last:justify;width:100%">KAREN MARINI</small>
         </div>
       </div>
 

--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
       --bg:#000;--card:#0e0e0e;--lift:#181818;
       --border:rgba(255,255,255,.08);--bh:rgba(255,255,255,.18);
       --text:#fff;--muted:rgba(255,255,255,.4);--r:6px;
-      --accent:#FFCC00;--panel:rgba(10,10,10,.94);--line:rgba(255,255,255,.1);
+      --accent:#FFD700;--panel:rgba(10,10,10,.94);--line:rgba(255,255,255,.1);
     }
     *,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
     body{font-family:'Inter',system-ui,sans-serif;background:var(--bg);color:var(--text);
@@ -21,16 +21,16 @@
       overflow:hidden;height:100vh}
 
     /* ── HEADER ── */
-    header{height:52px;padding:0 20px;border-bottom:1px solid var(--border);
+    header{height:64px;padding:0 20px;border-bottom:1px solid var(--border);
       display:flex;align-items:center;justify-content:space-between;
       position:fixed;top:0;left:0;right:0;z-index:200;
       background:color-mix(in srgb, var(--bg) 92%, transparent);backdrop-filter:blur(20px)}
     .logo-wrap{display:flex;align-items:center;gap:12px}
-    .logo-mark{width:28px;height:28px;border:2px solid var(--accent);
-      display:flex;align-items:center;justify-content:center;font-size:11px;font-weight:600;letter-spacing:0}
+    .logo-mark{width:30px;height:30px;background:var(--accent);border:none;
+      display:flex;align-items:center;justify-content:center;font-size:12px;font-weight:700;letter-spacing:0;color:#000}
     .logo-text-group{display:flex;flex-direction:column;gap:0px}
-    .branding-signature{font-size:7px;letter-spacing:3px;text-transform:uppercase;color:rgba(255,255,255,.35);font-weight:300;line-height:1.2}
-    .logo-name{font-size:15px;font-weight:300;letter-spacing:4px;text-transform:uppercase;line-height:1.1}
+    .branding-signature{font-size:7px;letter-spacing:4px;text-transform:uppercase;color:rgba(255,255,255,.32);font-weight:200;line-height:1;margin-bottom:6px;display:block}
+    .logo-name{font-size:2.2rem;font-weight:200;letter-spacing:6px;text-transform:uppercase;line-height:1;color:#fff}
     .logo-name em{color:var(--accent);font-style:normal}
     .header-nav{display:flex;gap:24px}
     .header-nav a{font-size:9px;letter-spacing:2.5px;text-transform:uppercase;
@@ -38,7 +38,7 @@
     .header-nav a:hover{color:var(--text)}
 
     /* ── MAIN VIEWPORT ── */
-    .viewport{position:fixed;top:52px;left:0;right:0;bottom:0}
+    .viewport{position:fixed;top:64px;left:0;right:0;bottom:0}
 
     /* SVG background */
     .map-bg{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;pointer-events:none;z-index:0}
@@ -244,7 +244,7 @@
     }
     .leaflet-container { background: #000 !important; }
     #open-full-report {
-      background: #FFF !important;
+      background: var(--accent) !important;
       color: #000 !important;
       border: none !important;
       border-radius: 50px !important;
@@ -265,7 +265,7 @@
     /* ── INFORME TÉCNICO MODAL v4 ────────────────────────── */
     .btn-full-report{
       display:none;width:100%;margin-top:10px;
-      background:#fff;color:#000;border:none;border-radius:50px;
+      background:var(--accent);color:#000;border:none;border-radius:50px;
       padding:12px 20px;font-family:'Inter',inherit;font-size:10px;
       font-weight:600;letter-spacing:2px;text-transform:uppercase;
       cursor:pointer;transition:opacity .2s,transform .1s;
@@ -677,6 +677,15 @@
     <button id="close-full-report" title="Cerrar">&times;</button>
 
     <div class="frm-body">
+
+      <!-- LOGO INSTITUCIONAL -->
+      <div style="display:flex;align-items:center;gap:10px;margin-bottom:32px">
+        <div style="width:30px;height:30px;background:var(--accent);display:flex;align-items:center;justify-content:center;font-size:12px;font-weight:700;color:#000;flex-shrink:0">E</div>
+        <div style="display:flex;flex-direction:column;gap:3px">
+          <small style="font-size:7px;letter-spacing:4px;text-transform:uppercase;color:rgba(255,255,255,.32);font-weight:200">KAREN MARINI</small>
+          <span style="font-size:1.4rem;font-weight:200;letter-spacing:5px;text-transform:uppercase;color:#fff;line-height:1">Edific<em style="color:var(--accent);font-style:normal">IA</em></span>
+        </div>
+      </div>
 
       <!-- MÓDULO HERO: dirección + mapa -->
       <div class="frm-hero-row">


### PR DESCRIPTION
## Cambios

- Ícono E: borde blanco 1.5px sin relleno (antes amarillo sólido)
- Texto DIFICIA: DIFIC blanco + IA amarillo (E vive en el ícono)
- KAREN MARINI debajo del logo con justify para igualar ancho
- Logo 20% más grande (36px box, 2.6rem texto)
- Logo en informe: 44px box, 2rem texto, misma estructura
- padding-left:4px en logo-wrap para separar del borde