### PR TITLE
feat: Consulta Normativa IA — mini-chat en panel derecho del informe

### DIFF
--- a/index.html
+++ b/index.html
@@ -426,6 +426,129 @@
       .frm-hero-address{font-size:1.4rem}
     }
 
+
+    /* ── REPORT CHAT PANEL ─────────────────────────────────── */
+    .frm-with-chat {
+      display: flex;
+      height: 100%;
+    }
+    .frm-main-col {
+      flex: 1;
+      min-width: 0;
+      overflow-y: auto;
+    }
+    #report-chat-container {
+      width: 320px;
+      flex-shrink: 0;
+      border-left: 1px solid #222;
+      background: #000;
+      display: flex;
+      flex-direction: column;
+      height: 100vh;
+      position: sticky;
+      top: 0;
+    }
+    .rc-header {
+      padding: 18px 16px 14px;
+      border-bottom: 1px solid #1a1a1a;
+      flex-shrink: 0;
+    }
+    .rc-label {
+      font-size: 9px; letter-spacing: 4px; text-transform: uppercase;
+      color: #E8C547; font-weight: 500; display: block; margin-bottom: 4px;
+    }
+    .rc-sublabel {
+      font-size: 10px; color: rgba(255,255,255,.3); letter-spacing: .5px;
+    }
+    .rc-messages {
+      flex: 1;
+      overflow-y: auto;
+      padding: 12px;
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+    }
+    .rc-msg {
+      font-size: 13px; line-height: 1.5;
+      padding: 8px 10px; border-radius: 6px;
+      max-width: 100%;
+    }
+    .rc-msg.user {
+      background: rgba(255,255,255,.06);
+      color: rgba(255,255,255,.85);
+      align-self: flex-end;
+    }
+    .rc-msg.assistant {
+      color: rgba(255,255,255,.8);
+    }
+    .rc-msg.assistant b { color: #E8C547; }
+    .rc-msg.assistant code {
+      background: rgba(255,255,255,.08);
+      padding: 1px 4px; border-radius: 3px;
+      font-size: 11px;
+    }
+    .rc-msg.info {
+      font-size: 10px; letter-spacing: .5px;
+      color: rgba(255,255,255,.25); font-style: italic;
+    }
+    .rc-msg.working {
+      color: rgba(255,255,255,.3); font-size: 12px;
+      animation: rc-blink .8s infinite;
+    }
+    .rc-msg.error { color: #f87171; font-size: 12px; }
+    @keyframes rc-blink { 0%,100%{opacity:.3} 50%{opacity:1} }
+
+    .rc-chips {
+      padding: 8px 12px;
+      display: flex; flex-wrap: wrap; gap: 6px;
+      border-top: 1px solid #1a1a1a;
+      flex-shrink: 0;
+    }
+    .rc-chip {
+      font-size: 10px; letter-spacing: .5px;
+      padding: 5px 10px; border-radius: 100px;
+      border: 1px solid rgba(255,255,255,.12);
+      color: rgba(255,255,255,.5);
+      cursor: pointer; background: none;
+      transition: border-color .2s, color .2s;
+      white-space: nowrap;
+    }
+    .rc-chip:hover { border-color: #E8C547; color: #E8C547; }
+
+    .rc-input-row {
+      padding: 10px 12px;
+      border-top: 1px solid #1a1a1a;
+      display: flex; gap: 8px; align-items: flex-end;
+      flex-shrink: 0;
+    }
+    .rc-input {
+      flex: 1; background: rgba(255,255,255,.05);
+      border: 1px solid rgba(255,255,255,.1);
+      border-radius: 8px; padding: 9px 12px;
+      color: #fff; font: 13px/1.4 'Inter', inherit;
+      resize: none; outline: none; min-height: 36px; max-height: 80px;
+      transition: border-color .2s;
+    }
+    .rc-input::placeholder { color: rgba(255,255,255,.25); font-size: 12px; }
+    .rc-input:focus { border-color: rgba(232,197,71,.4); }
+    .rc-send {
+      width: 34px; height: 34px; flex-shrink: 0;
+      background: #E8C547; color: #000; border: none;
+      border-radius: 8px; cursor: pointer; font-size: 14px;
+      display: flex; align-items: center; justify-content: center;
+      transition: opacity .2s;
+    }
+    .rc-send:hover { opacity: .85; }
+    .rc-send:disabled { opacity: .35; cursor: default; }
+
+    @media(max-width:900px) {
+      .frm-with-chat { flex-direction: column; }
+      #report-chat-container {
+        width: 100%; height: 360px; border-left: none;
+        border-top: 1px solid #222; position: static;
+      }
+    }
+
     </style></defs>
       <path class="av2" d="M80,50 L500,38 L545,100 L560,240 L540,380 L510,490 L455,590 L360,650 L240,658 L140,620 L80,550 L45,420 L35,260 L55,130 Z" opacity=".45"/>
       <path d="M500,38 L545,100 L560,240 L540,380 L510,490 L455,590" stroke="#fff" stroke-width=".3" fill="none" opacity=".1" stroke-dasharray="5,4"/>
@@ -674,6 +797,8 @@
   <div id="full-report-modal" class="formal-report hidden">
     <button id="close-full-report" title="Cerrar">&times;</button>
 
+    <div class="frm-with-chat">
+    <div class="frm-main-col">
     <div class="frm-body">
 
       <!-- LOGO INSTITUCIONAL -->
@@ -778,6 +903,30 @@
       <!-- FOOTER -->
       <div class="frm-footer-note">
         Informe de carácter preliminar. No constituye autorización de obra ni verificación jurídica. Datos sujetos a verificación profesional ante el GCBA.
+      </div>
+
+    </div>
+    </div>
+
+      <!-- PANEL DE CHAT IA -->
+      <div id="report-chat-container">
+        <div class="rc-header">
+          <span class="rc-label">Consulta Normativa IA</span>
+          <span class="rc-sublabel">Preguntá sobre esta parcela</span>
+        </div>
+        <div class="rc-messages" id="rc-messages"></div>
+        <div class="rc-chips" id="rc-chips">
+          <button class="rc-chip" onclick="rcSendChip(this)">¿Qué se puede construir?</button>
+          <button class="rc-chip" onclick="rcSendChip(this)">¿Cuál es la plusvalía?</button>
+          <button class="rc-chip" onclick="rcSendChip(this)">Restricciones del distrito</button>
+          <button class="rc-chip" onclick="rcSendChip(this)">¿Conviene desarrollar?</button>
+        </div>
+        <div class="rc-input-row">
+          <textarea id="rc-input" class="rc-input" rows="1"
+            placeholder="Preguntá sobre la parcela..." 
+            onkeydown="if(event.key==='Enter'&&!event.shiftKey){event.preventDefault();rcSend()}"></textarea>
+          <button class="rc-send" id="rc-send-btn" onclick="rcSend()">↑</button>
+        </div>
       </div>
 
     </div>

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -781,6 +781,12 @@ function openFullReport() {
     }, 150);
   }
 
+  // Inicializar chat
+  const _rcCtx2 = [getText('res-addr'),getText('res-badge'),
+    'Lote: '+getVal('c-sup')+'m²','Vendible: '+getText('full-total')+'m²'
+  ].filter(Boolean).join('\n');
+  rcInit(_rcCtx2);
+
   modal.classList.remove('hidden');
   document.body.style.overflow = 'hidden';
 }

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -824,3 +824,150 @@ document.addEventListener('DOMContentLoaded', () => {
   const res = document.getElementById('results');
   if (res) _resultsObserver.observe(res, { attributes: true, attributeFilter: ['class'] });
 });
+
+
+// ── REPORT CHAT — mini-chat independiente en el modal ────────────
+// NO toca chat.js. Llama a /api/chat directamente con SSE.
+
+let _rcSessionId   = null;
+let _rcStreaming    = false;
+let _rcAbortCtrl   = null;
+
+function rcInit(parcelContext) {
+  // Nueva sesión por cada apertura del informe
+  _rcSessionId = crypto.randomUUID();
+  _rcStreaming  = false;
+
+  const messagesEl = document.getElementById('rc-messages');
+  if (!messagesEl) return;
+  messagesEl.innerHTML = '';
+
+  // Mensaje de bienvenida con contexto
+  const info = document.createElement('div');
+  info.className = 'rc-msg info';
+  info.textContent = parcelContext
+    ? '📍 ' + parcelContext.split('\n')[0]
+    : 'Informe cargado. Podés preguntar sobre esta parcela.';
+  messagesEl.appendChild(info);
+
+  // Guardar el contexto para el primer mensaje
+  window._rcPendingContext = parcelContext || '';
+}
+
+function rcScrollBottom() {
+  const el = document.getElementById('rc-messages');
+  if (el) el.scrollTop = el.scrollHeight;
+}
+
+async function rcSend(textOverride) {
+  if (_rcStreaming) return;
+  const inputEl = document.getElementById('rc-input');
+  const sendBtn = document.getElementById('rc-send-btn');
+  const messagesEl = document.getElementById('rc-messages');
+  if (!messagesEl) return;
+
+  const text = textOverride || inputEl?.value?.trim();
+  if (!text) return;
+  if (inputEl) inputEl.value = '';
+
+  // Prepend context in first message
+  let agentMessage = text;
+  if (window._rcPendingContext) {
+    agentMessage = window._rcPendingContext + '\n\n' + text;
+    window._rcPendingContext = '';
+  }
+
+  // Render user message
+  const userEl = document.createElement('div');
+  userEl.className = 'rc-msg user';
+  userEl.textContent = text;
+  messagesEl.appendChild(userEl);
+  rcScrollBottom();
+
+  // Render assistant placeholder
+  const assistEl = document.createElement('div');
+  assistEl.className = 'rc-msg assistant';
+  messagesEl.appendChild(assistEl);
+
+  const workEl = document.createElement('div');
+  workEl.className = 'rc-msg working';
+  workEl.textContent = 'Analizando...';
+  messagesEl.appendChild(workEl);
+  rcScrollBottom();
+
+  _rcStreaming = true;
+  if (sendBtn) sendBtn.disabled = true;
+
+  _rcAbortCtrl = new AbortController();
+  let accumulated = '';
+
+  try {
+    const resp = await fetch('/api/chat', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        session_id: _rcSessionId,
+        message: agentMessage,
+        model: 'claude-haiku-4-5-20251001'
+      }),
+      signal: _rcAbortCtrl.signal
+    });
+
+    if (!resp.ok) {
+      workEl.remove();
+      assistEl.className = 'rc-msg error';
+      assistEl.textContent = 'Error ' + resp.status + ' — intentá nuevamente';
+      return;
+    }
+
+    const reader  = resp.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split('\n');
+      buffer = lines.pop();
+
+      for (const line of lines) {
+        if (!line.startsWith('data: ')) continue;
+        try {
+          const ev = JSON.parse(line.slice(6));
+          if (ev.type === 'text') {
+            accumulated += ev.data;
+            // Render markdown simple
+            assistEl.innerHTML = accumulated
+              .replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;')
+              .replace(/\*\*([^*]+)\*\*/g,'<b>$1</b>')
+              .replace(/`([^`]+)`/g,'<code>$1</code>')
+              .replace(/\n/g,'<br>');
+            rcScrollBottom();
+          } else if (ev.type === 'working') {
+            workEl.style.display = ev.data ? 'block' : 'none';
+          }
+        } catch { /* skip */ }
+      }
+    }
+
+    workEl.remove();
+    assistEl.classList.add('done');
+
+  } catch(e) {
+    workEl.remove();
+    if (e.name !== 'AbortError') {
+      assistEl.className = 'rc-msg error';
+      assistEl.textContent = e.message;
+    }
+  } finally {
+    _rcStreaming = false;
+    _rcAbortCtrl = null;
+    if (sendBtn) sendBtn.disabled = false;
+    rcScrollBottom();
+  }
+}
+
+function rcSendChip(btn) {
+  rcSend(btn.textContent.trim());
+}


### PR DESCRIPTION
## Qué agrega

Panel de chat independiente en el lado derecho del modal de informe (25% del ancho).

### Arquitectura
- **NO toca `chat.js`** — mini-chat autocontenido en `app.js`
- Llama a `/api/chat` directamente con SSE (mismo protocolo que el chat principal)
- Sesión nueva por cada apertura del informe (`crypto.randomUUID()`)
- Contexto de la parcela pre-cargado en el primer mensaje

### Layout
- `frm-with-chat`: flex row — `frm-main-col` (flex:1) + `#report-chat-container` (320px)
- Responsive: en mobile se apila verticalmente (360px alto)

### Features del chat
- Contexto automático: dirección, distrito, lote, altura, pisos, FOT, vendibles
- 4 chips de preguntas frecuentes: "¿Qué se puede construir?", "¿Cuál es la plusvalía?", etc.
- Textarea multi-línea + botón amarillo `#E8C547`
- Streaming SSE con markdown básico (`**bold**`, `` `code` ``)
- Indicador "Analizando..." durante la respuesta

### NO se modifica
- `chat.js` — intacto
- `map.js` — intacto
- Ninguna función de cálculo existente

cc @juanwisz