### PR TITLE
fix: report-chat — addEventListener en módulo ES (onclick inline no funciona)

### DIFF
--- a/index.html
+++ b/index.html
@@ -916,16 +916,16 @@
         </div>
         <div class="rc-messages" id="rc-messages"></div>
         <div class="rc-chips" id="rc-chips">
-          <button class="rc-chip" onclick="rcSendChip(this)">¿Qué se puede construir?</button>
-          <button class="rc-chip" onclick="rcSendChip(this)">¿Cuál es la plusvalía?</button>
-          <button class="rc-chip" onclick="rcSendChip(this)">Restricciones del distrito</button>
-          <button class="rc-chip" onclick="rcSendChip(this)">¿Conviene desarrollar?</button>
+          <button class="rc-chip" data-question="¿Qué se puede construir?">¿Qué se puede construir?</button>
+          <button class="rc-chip" data-question="¿Cuál es la plusvalía?">¿Cuál es la plusvalía?</button>
+          <button class="rc-chip" data-question="Restricciones del distrito">Restricciones del distrito</button>
+          <button class="rc-chip" data-question="¿Conviene desarrollar?">¿Conviene desarrollar?</button>
         </div>
         <div class="rc-input-row">
           <textarea id="rc-input" class="rc-input" rows="1"
             placeholder="Preguntá sobre la parcela..." 
-            onkeydown="if(event.key==='Enter'&&!event.shiftKey){event.preventDefault();rcSend()}"></textarea>
-          <button class="rc-send" id="rc-send-btn" onclick="rcSend()">↑</button>
+            ></textarea>
+          <button class="rc-send" id="rc-send-btn">↑</button>
         </div>
       </div>
 

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -848,7 +848,7 @@ function rcInit(parcelContext) {
   if (!messagesEl) return;
   messagesEl.innerHTML = '';
 
-  // Mensaje de bienvenida con contexto
+  // Mensaje de bienvenida
   const info = document.createElement('div');
   info.className = 'rc-msg info';
   info.textContent = parcelContext
@@ -856,8 +856,36 @@ function rcInit(parcelContext) {
     : 'Informe cargado. Podés preguntar sobre esta parcela.';
   messagesEl.appendChild(info);
 
-  // Guardar el contexto para el primer mensaje
+  // Contexto para el primer mensaje
   window._rcPendingContext = parcelContext || '';
+
+  // ── Bindear eventos (módulo ES — no se pueden usar onclick inline) ──
+  const sendBtn = document.getElementById('rc-send-btn');
+  const inputEl = document.getElementById('rc-input');
+
+  // Clonar para quitar listeners anteriores
+  if (sendBtn) {
+    const fresh = sendBtn.cloneNode(true);
+    sendBtn.parentNode.replaceChild(fresh, sendBtn);
+    fresh.addEventListener('click', () => rcSend());
+  }
+  if (inputEl) {
+    const fresh = inputEl.cloneNode(true);
+    inputEl.parentNode.replaceChild(fresh, inputEl);
+    fresh.addEventListener('keydown', e => {
+      if (e.key === 'Enter' && !e.shiftKey) {
+        e.preventDefault();
+        rcSend();
+      }
+    });
+  }
+
+  // Bindear chips
+  document.querySelectorAll('#rc-chips .rc-chip').forEach(chip => {
+    const fresh = chip.cloneNode(true);
+    chip.parentNode.replaceChild(fresh, chip);
+    fresh.addEventListener('click', () => rcSend(fresh.dataset.question));
+  });
 }
 
 function rcScrollBottom() {
@@ -867,7 +895,8 @@ function rcScrollBottom() {
 
 async function rcSend(textOverride) {
   if (_rcStreaming) return;
-  const inputEl = document.getElementById('rc-input');
+  // Buscar el input fresco (puede haber sido clonado en rcInit)
+  const inputEl = document.getElementById('rc-input') || document.querySelector('#report-chat-container textarea');
   const sendBtn = document.getElementById('rc-send-btn');
   const messagesEl = document.getElementById('rc-messages');
   if (!messagesEl) return;
@@ -974,6 +1003,3 @@ async function rcSend(textOverride) {
   }
 }
 
-function rcSendChip(btn) {
-  rcSend(btn.textContent.trim());
-}


### PR DESCRIPTION
## Causa raíz

`app.js` es `type="module"` → las funciones no están en el scope global → `onclick="rcSend()"` falla silenciosamente.

## Fix
- Quitar todos los `onclick` inline del HTML del chat del informe
- `rcInit()` bindea los eventos via `addEventListener` desde dentro del módulo
- Clona los elementos antes de bindear para evitar listeners duplicados en cada apertura
- Los chips usan `data-question` en vez de `onclick`

## NO se toca
- `chat.js` — intacto
- `map.js` — intacto

cc @juanwisz