### PR TITLE
feat: botón Agente EdificIA con logo Claude + hide al abrir chat

### DIFF
--- a/index.html
+++ b/index.html
@@ -135,15 +135,16 @@
     /* Chat pill — botón principal de acceso a IA */
     #chat-toggle{
       position:fixed;bottom:20px;left:16px;z-index:500;
-      display:flex;align-items:center;gap:9px;
-      padding:13px 22px;border-radius:100px;
+      display:flex;align-items:center;gap:10px;
+      padding:14px 28px 14px 22px;border-radius:100px;
       background:var(--accent);color:#000;border:none;cursor:pointer;
-      font-family:'Inter',system-ui,sans-serif;font-size:10px;font-weight:700;
-      letter-spacing:2px;text-transform:uppercase;
+      font-family:'Inter',system-ui,sans-serif;font-size:11px;font-weight:600;
+      letter-spacing:2.5px;text-transform:uppercase;white-space:nowrap;
       box-shadow:0 0 28px rgba(255,215,0,.28),0 4px 16px rgba(0,0,0,.5);
-      transition:transform .15s,box-shadow .15s;
+      transition:transform .15s,box-shadow .15s,opacity .2s;
     }
-    #chat-toggle:hover{transform:translateY(-2px);box-shadow:0 0 36px rgba(255,215,0,.42),0 6px 20px rgba(0,0,0,.5)}
+    #chat-toggle:hover{transform:translateY(-2px);box-shadow:0 0 40px rgba(255,215,0,.45),0 6px 20px rgba(0,0,0,.5)}
+    #chat-toggle.hidden{opacity:0;pointer-events:none;transform:translateY(8px)}
 
     /* ── RESULTS (scrollable detail below map) ── */
     #results{display:none;position:absolute;top:0;right:0;bottom:0;width:420px;z-index:100;
@@ -789,9 +790,25 @@
 
 </div>
 
-<button id="chat-toggle" title="Consultar IA (Ctrl+K)">
-  <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>
-  CONSULTAR IA
+<button id="chat-toggle" title="Agente EdificIA (Ctrl+K)">
+  <!-- Claude starburst logo -->
+  <svg width="16" height="16" viewBox="0 0 30 30" fill="currentColor" style="flex-shrink:0">
+    <g transform="translate(15,15)">
+      <rect x="-1.3" y="-13" width="2.6" height="10" rx="1.3" transform="rotate(0)"/>
+      <rect x="-1.3" y="-13" width="2.6" height="10" rx="1.3" transform="rotate(30)"/>
+      <rect x="-1.3" y="-13" width="2.6" height="10" rx="1.3" transform="rotate(60)"/>
+      <rect x="-1.3" y="-13" width="2.6" height="10" rx="1.3" transform="rotate(90)"/>
+      <rect x="-1.3" y="-13" width="2.6" height="10" rx="1.3" transform="rotate(120)"/>
+      <rect x="-1.3" y="-13" width="2.6" height="10" rx="1.3" transform="rotate(150)"/>
+      <rect x="-1.3" y="-13" width="2.6" height="10" rx="1.3" transform="rotate(180)"/>
+      <rect x="-1.3" y="-13" width="2.6" height="10" rx="1.3" transform="rotate(210)"/>
+      <rect x="-1.3" y="-13" width="2.6" height="10" rx="1.3" transform="rotate(240)"/>
+      <rect x="-1.3" y="-13" width="2.6" height="10" rx="1.3" transform="rotate(270)"/>
+      <rect x="-1.3" y="-13" width="2.6" height="10" rx="1.3" transform="rotate(300)"/>
+      <rect x="-1.3" y="-13" width="2.6" height="10" rx="1.3" transform="rotate(330)"/>
+    </g>
+  </svg>
+  AGENTE EDIFICIA
 </button>
 
 <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>

--- a/static/js/chat.js
+++ b/static/js/chat.js
@@ -173,6 +173,7 @@ export function setChatMode(mode) {
   const c = _chatContainer;
   const leftPanel = document.getElementById('leftPanel');
   const histBtn = document.getElementById('chat-history-btn');
+  const toggleBtn = document.getElementById('chat-toggle');
 
   c.className = '';
   if (mode === 'hidden') {
@@ -181,6 +182,8 @@ export function setChatMode(mode) {
     histBtn.style.display = 'none';
     _historyPanel.style.display = 'none';
     _historyOpen = false;
+    // Reappear the access button
+    if (toggleBtn) toggleBtn.classList.remove('hidden');
   } else if (mode === 'sidebar') {
     c.style.display = 'flex';
     c.classList.add('chat-sidebar');
@@ -189,12 +192,16 @@ export function setChatMode(mode) {
     _historyPanel.style.display = 'none';
     _historyOpen = false;
     _inputEl.focus();
+    // Hide the access button so it doesn't overlap the input
+    if (toggleBtn) toggleBtn.classList.add('hidden');
   } else if (mode === 'fullscreen') {
     c.style.display = 'flex';
     c.classList.add('chat-fullscreen');
     if (leftPanel) leftPanel.style.display = 'none';
     histBtn.style.display = '';
     _inputEl.focus();
+    // Hide the access button in fullscreen too
+    if (toggleBtn) toggleBtn.classList.add('hidden');
   }
 }
 


### PR DESCRIPTION
## Cambios

**Botón:**
- Texto: CONSULTAR IA → AGENTE EDIFICIA
- Ícono: starburst SVG 12 rayos estilo Claude (inline)
- Padding extendido 14px 28px, font-weight:600

**UX:**
- Al abrir chat (sidebar/fullscreen): botón desaparece con fade+slide
- Al cerrar chat: botón reaparece con transición suave
- CSS: .hidden → opacity:0 + pointer-events:none + translateY(8px)