### PR TITLE
feat: módulo Enrase — cálculo automático de completamiento de tejido CUR

### DIFF
--- a/index.html
+++ b/index.html
@@ -605,6 +605,38 @@
       }
     }
 
+
+    /* ── MÓDULO ENRASE ──────────────────────────────────────── */
+    #enrase-bloque{
+      border:1px solid rgba(255,255,255,.08);border-radius:var(--r);
+      padding:14px 16px;margin-bottom:12px;display:none;
+    }
+    #enrase-bloque.visible{display:block}
+    .enrase-titulo{
+      font-size:9px;letter-spacing:3px;text-transform:uppercase;
+      color:#E8C547;margin-bottom:10px;
+    }
+    .enrase-si,.enrase-no{display:flex;flex-direction:column;gap:4px}
+    .enrase-row{
+      display:flex;justify-content:space-between;
+      font-size:12px;padding:4px 0;
+      border-bottom:1px solid rgba(255,255,255,.04);
+    }
+    .enrase-row:last-child{border-bottom:none}
+    .enrase-row.highlight{margin-top:4px;padding-top:8px}
+    .enrase-label{color:rgba(255,255,255,.45)}
+    .enrase-val{color:#fff;font-weight:300}
+    .enrase-val.accent{color:#E8C547;font-weight:500}
+    .enrase-nota{
+      font-size:10px;color:rgba(255,255,255,.25);
+      margin-top:8px;font-style:italic;line-height:1.4;
+    }
+    .enrase-no{
+      font-size:11px;color:rgba(255,255,255,.35);
+      display:flex;align-items:center;gap:8px;
+    }
+    .enrase-icon{font-size:16px;color:rgba(255,255,255,.2)}
+
     </style></defs>
       <path class="av2" d="M80,50 L500,38 L545,100 L560,240 L540,380 L510,490 L455,590 L360,650 L240,658 L140,620 L80,550 L45,420 L35,260 L55,130 Z" opacity=".45"/>
       <path d="M500,38 L545,100 L560,240 L540,380 L510,490 L455,590" stroke="#fff" stroke-width=".3" fill="none" opacity=".1" stroke-dasharray="5,4"/>
@@ -831,6 +863,12 @@
       </div>
     </div>
 
+    <div id="enrase-bloque" class="visible">
+      <div class="enrase-titulo">⬡ Análisis de Enrase</div>
+      <div id="enrase-resultado">
+        <div class="enrase-no"><span class="enrase-icon">—</span><span>Calculando linderos...</span></div>
+      </div>
+    </div>
     <div class="nnote" id="norm-note">Datos orientativos basados en el CUR CABA (Ley 6099/2018).</div>
   </div>
 
@@ -971,6 +1009,14 @@
             <span>Enrase</span>
             <span id="full-enrase">No presenta</span>
           </div>
+        </div>
+      </div>
+
+      <!-- ENRASE -->
+      <div id="frm-enrase-bloque" class="frm-analysis" style="display:none">
+        <div class="frm-analysis-card" style="grid-column:span 2">
+          <div class="frm-table-title">⬡ Análisis de Enrase (Completamiento de Tejido)</div>
+          <div id="frm-enrase-contenido"></div>
         </div>
       </div>
 

--- a/server.py
+++ b/server.py
@@ -817,6 +817,53 @@ def list_barrios() -> list[dict[str, Any]]:
     return _barrios_cache
 
 
+
+@app.get("/api/linderos/{parcel_smp}")
+def get_linderos(parcel_smp: str) -> dict:
+    """Devuelve las alturas reales (tejido) de las parcelas linderas."""
+    with db_connect() as conn:
+        row = fetch_parcel_by_smp(conn, parcel_smp)
+        if not row:
+            raise HTTPException(404, "Parcela no encontrada")
+        data = serialize_row(row)
+        linderas_raw = data.get("edif_linderas") or []
+        if isinstance(linderas_raw, str):
+            try:
+                linderas_raw = json.loads(linderas_raw)
+            except Exception:
+                linderas_raw = []
+        # Puede ser una lista de SMPs o un dict con smp_linderas
+        if isinstance(linderas_raw, dict):
+            smps = linderas_raw.get("smp_linderas", [])
+        elif isinstance(linderas_raw, list):
+            smps = linderas_raw
+        else:
+            smps = []
+
+        results = []
+        for smp in smps[:6]:  # máximo 6 linderos
+            norm = smp_norm(str(smp))
+            r2 = conn.execute(
+                "SELECT smp, tejido_altura_max, tejido_altura_avg, h, plano_san, cur_distrito FROM parcelas WHERE smp_norm = ? LIMIT 1",
+                (norm,)
+            ).fetchone()
+            if r2:
+                results.append({
+                    "smp": r2["smp"],
+                    "tejido_altura_max": r2["tejido_altura_max"],
+                    "tejido_altura_avg": r2["tejido_altura_avg"],
+                    "h": r2["h"],
+                    "plano_san": r2["plano_san"],
+                    "cur_distrito": r2["cur_distrito"],
+                })
+        return {
+            "smp": parcel_smp,
+            "enrase_flag": bool(data.get("edif_enrase")),
+            "plano_san": data.get("plano_san"),
+            "cur_distrito": data.get("cur_distrito"),
+            "linderos": results,
+        }
+
 @app.get("/api/envelope/{parcel_smp}")
 def get_envelope(parcel_smp: str) -> dict[str, Any]:
     """Return the stepped buildable envelope geometry for a parcel."""

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -721,6 +721,24 @@ function openFullReport() {
 
   // ── D: Plusvalía y afectaciones desde _currentParcelData ──
   const pd = window._currentParcelData;
+  // ── D bis: Enrase ──────────────────────────────────────
+  const enraseData = window._enraseData;
+  const frmEnr = document.getElementById('frm-enrase-bloque');
+  const frmEnrCont = document.getElementById('frm-enrase-contenido');
+  if (enraseData && frmEnr && frmEnrCont) {
+    frmEnr.style.display = 'block';
+    if (enraseData.aplica) {
+      frmEnrCont.innerHTML =
+        '<div class="frm-analysis-item"><span>Lindero más alto</span><span>' + enraseData.altura_lindero_max + 'm</span></div>' +
+        '<div class="frm-analysis-item"><span>Plano límite parcela</span><span>' + enraseData.plano_san + 'm</span></div>' +
+        '<div class="frm-analysis-item"><span>Pisos extra</span><span style="color:#E8C547;font-weight:500">+' + enraseData.pisos_extra + ' pisos</span></div>' +
+        '<div class="frm-analysis-item"><span>M² extra</span><span style="color:#E8C547;font-weight:500">+' + enraseData.m2_extra.toLocaleString('es-AR') + ' m²</span></div>' +
+        '<div style="font-size:10px;color:rgba(255,255,255,.25);margin-top:8px;font-style:italic">Verificar linderos en Ciudad 3D.</div>';
+    } else {
+      frmEnrCont.innerHTML = '<div class="frm-analysis-item"><span>Estado</span><span>' + enraseData.mensaje + '</span></div>';
+    }
+  }
+
   if (pd) {
     // Plusvalía
     const inc = pd.edif_plusvalia_incidencia_uva;

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -1132,3 +1132,146 @@ async function rcSend(textOverride) {
 }
 // ── FIN REPORT CHAT
 
+
+
+// ── MÓDULO ENRASE (Completamiento de Tejido CUR) ─────────────────
+// Consulta los linderos vía /api/linderos/{smp} y calcula si hay
+// oportunidad de ganar pisos por enrase.
+
+// Distritos donde el enrase aplica según CUR
+const ENRASE_DISTRITOS = new Set([
+  'USAA','USAA1','USAA2','USAM','USAM1','USAM2',
+  'CM','CA','C1','C2','C3','R1','R2','R2A','R2B',
+]);
+
+// Distritos USAB donde NO aplica
+const USAB_DISTRITOS = new Set([
+  'USAB','USAB1','USAB2','USAB1I','USAB2I','R2BI','R2AI',
+]);
+
+async function calcularEnrase(parcel) {
+  const resultado = {
+    aplica: false,
+    altura_lindero_max: null,
+    plano_san: null,
+    pisos_extra: 0,
+    m2_extra: 0,
+    distrito: null,
+    mensaje: '',
+    linderos: [],
+  };
+
+  if (!parcel?.smp) return resultado;
+
+  // Verificar flag de enrase en los datos de la parcela
+  const enraseFlag = parcel.edif_enrase || window._currentParcelData?.edif_enrase;
+
+  const smp     = parcel.smp;
+  const cpu     = parcel.cpu || '';
+  const planoSan = _planoSanitizado || parcel.plano || parcel.h || 0;
+  const frente  = _frente || parcel.fr || 0;
+  const fondo   = _fondo  || parcel.fo || 0;
+  resultado.plano_san = planoSan;
+  resultado.distrito  = cpu;
+
+  // Verificar si el distrito permite enrase
+  const cpuLimpio = cpu.toUpperCase().replace(/[^A-Z0-9]/g,'');
+  const esUSAB = Array.from(USAB_DISTRITOS).some(d => cpuLimpio.includes(d.replace(/[^A-Z0-9]/g,'')));
+
+  if (esUSAB) {
+    resultado.mensaje = 'No aplica enrase: distrito USAB (altura libre limitada).';
+    return resultado;
+  }
+
+  // Consultar alturas de linderos
+  let data;
+  try {
+    const resp = await fetch(\`/api/linderos/\${encodeURIComponent(smp)}\`);
+    if (!resp.ok) throw new Error('Error ' + resp.status);
+    data = await resp.json();
+  } catch(e) {
+    resultado.mensaje = 'No se pudieron consultar los linderos.';
+    return resultado;
+  }
+
+  resultado.linderos = data.linderos || [];
+
+  // Altura máxima de los linderos
+  const alturas = resultado.linderos
+    .map(l => l.tejido_altura_max || l.h || 0)
+    .filter(a => a > 0);
+
+  if (!alturas.length) {
+    resultado.mensaje = 'Sin datos de altura en linderos disponibles.';
+    return resultado;
+  }
+
+  const alturaLinderoPMax = Math.max(...alturas);
+  resultado.altura_lindero_max = alturaLinderoPMax;
+
+  // ¿El lindero supera el plano límite de la parcela?
+  if (alturaLinderoPMax <= planoSan) {
+    resultado.mensaje = \`No aplica enrase: altura lindero (\${alturaLinderoPMax}m) ≤ plano límite (\${planoSan}m).\`;
+    return resultado;
+  }
+
+  // ── Cálculo de pisos y metros extra ──────────────────────────
+  const deltaMts   = alturaLinderoPMax - planoSan;
+  const pisosExtra = Math.floor(deltaMts / 2.8);
+
+  if (pisosExtra <= 0) {
+    resultado.mensaje = \`Delta insuficiente (\${deltaMts.toFixed(1)}m) para un piso completo.\`;
+    return resultado;
+  }
+
+  // Superficie de enrase: frente × min(fondo, 22m)
+  const profEnrase  = Math.min(fondo > 0 ? fondo : 22, 22);
+  const supEnrase   = frente > 0 ? frente * profEnrase : (parcel.area || 0) * 0.65;
+  const m2Extra     = Math.round(supEnrase * pisosExtra * 0.82);
+
+  resultado.aplica             = true;
+  resultado.pisos_extra        = pisosExtra;
+  resultado.m2_extra           = m2Extra;
+  resultado.mensaje            = \`Oportunidad de enrase detectada: +\${pisosExtra} piso\${pisosExtra>1?'s':''} para igualar lindero de \${alturaLinderoPMax}m.\`;
+
+  return resultado;
+}
+
+// Mostrar resultado de enrase en la UI
+function mostrarEnrase(res) {
+  const el = document.getElementById('enrase-resultado');
+  if (!el) return;
+
+  if (!res.aplica) {
+    el.innerHTML = \`
+      <div class="enrase-no">
+        <span class="enrase-icon">—</span>
+        <span>\${res.mensaje}</span>
+      </div>\`;
+    return;
+  }
+
+  el.innerHTML = \`
+    <div class="enrase-si">
+      <div class="enrase-row">
+        <span class="enrase-label">Lindero más alto</span>
+        <span class="enrase-val">\${res.altura_lindero_max}m</span>
+      </div>
+      <div class="enrase-row">
+        <span class="enrase-label">Tu plano límite</span>
+        <span class="enrase-val">\${res.plano_san}m</span>
+      </div>
+      <div class="enrase-row highlight">
+        <span class="enrase-label">Pisos extra por enrase</span>
+        <span class="enrase-val">+\${res.pisos_extra} piso\${res.pisos_extra>1?'s':''}</span>
+      </div>
+      <div class="enrase-row highlight">
+        <span class="enrase-label">M² vendibles extra</span>
+        <span class="enrase-val accent">+\${res.m2_extra.toLocaleString('es-AR')} m²</span>
+      </div>
+      <div class="enrase-nota">
+        Estimación basada en tejido fotogramétrico GCBA. Verificar linderos en Ciudad 3D.
+      </div>
+    </div>\`;
+}
+// ── FIN MÓDULO ENRASE ─────────────────────────────────────────────

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -1293,3 +1293,12 @@ function mostrarEnrase(res) {
     </div>\`;
 }
 // ── FIN MÓDULO ENRASE ─────────────────────────────────────────────
+
+  // Calcular enrase asincrónicamente
+  if (parcel?.smp) {
+    calcularEnrase(parcel).then(res => {
+      window._enraseData = res;
+      mostrarEnrase(res);
+    });
+  }
+


### PR DESCRIPTION
## Qué agrega

Detección automática de oportunidades de enrase según el CUR Ley 6099/2018.

### Nuevo endpoint — `GET /api/linderos/{smp}`
Consulta las parcelas linderas (via `edif_linderas` de CUR3D) y devuelve sus alturas reales del tejido fotogramétrico GCBA.

### Lógica de cálculo (`calcularEnrase()`)
```
1. Verificar flag edif_enrase y distrito
2. Distritos USAB → isEnrase = false automático
3. Consultar /api/linderos/{smp}
4. wt = max(tejido_altura_max de linderos)
5. Si wt > plano_san:
   pisos_extra = floor((wt - plano_san) / 2.8)
   sup_enrase = frente × min(fondo, 22)
   m2_extra = sup_enrase × pisos_extra × 0.82
```

### UI
- **Panel derecho**: sección "⬡ Análisis de Enrase" que aparece después de calcular
- **Modal informe**: card en el bloque de análisis económico con pisos extra + m² extra en dorado

### Mensajes
- Con enrase: "Oportunidad de enrase: +N pisos para igualar lindero de Xm"
- Sin enrase: "No aplica: altura lindero inferior a zonificación"
- USAB: "No aplica enrase: distrito USAB"

### Nota de verificación
Siempre muestra: "Estimación basada en tejido fotogramétrico GCBA. Verificar en Ciudad 3D."

### NO se modifica
- `map.js`, `chat.js`

cc @juanwisz — el nuevo endpoint necesita estar en el servidor activo