### PR TITLE
fix: mover enrase fuera del top-level - el mapa no cargaba

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -239,6 +239,18 @@ function showParcelDetail(addr, parcel, lat, lng) {
   // Calculator
   setupCalculator(parcel, planoSan);
 
+  // Enrase: mostrar bloque y calcular asincrónicamente
+  const enraseBloque = document.getElementById('enrase-bloque');
+  if (enraseBloque) enraseBloque.classList.add('visible');
+  const enraseResult = document.getElementById('enrase-resultado');
+  if (enraseResult) enraseResult.innerHTML = '<div class="enrase-no"><span class="enrase-icon">—</span><span>Calculando linderos...</span></div>';
+  if (parcel?.smp) {
+    calcularEnrase(parcel).then(res => {
+      window._enraseData = res;
+      mostrarEnrase(res);
+    });
+  }
+
   // Guardar estado para el Full Report
   window._currentParcelData = parcel;
   window._currentLat = lat;
@@ -1293,12 +1305,4 @@ function mostrarEnrase(res) {
     </div>`;
 }
 // ── FIN MÓDULO ENRASE ─────────────────────────────────────────────
-
-  // Calcular enrase asincrónicamente
-  if (parcel?.smp) {
-    calcularEnrase(parcel).then(res => {
-      window._enraseData = res;
-      mostrarEnrase(res);
-    });
-  }
 


### PR DESCRIPTION
## Problema

El codigo del modulo enrase habia quedado fuera de toda funcion, al nivel raiz del modulo ES. La variable `parcel` no existe en ese scope, causando `ReferenceError: parcel is not defined` al parsear app.js. Esto impedia que `initApp()` se ejecutara y el mapa Leaflet nunca se inicializaba.

## Fix

- Elimina el bloque huerfano de lineas ~1297-1303 (nivel top-level)
- Inserta la llamada a `calcularEnrase()` dentro de `showParcelDetail()` justo despues de `setupCalculator()`, donde `parcel` esta definido como parametro
- Al abrir un predio: muestra 'Calculando linderos...' y actualiza al recibir respuesta

## Test

1. Cargar la app -> el mapa Leaflet aparece
2. Buscar parcela -> bloque enrase con 'Calculando...' y luego resultado