### PR TITLE
fix: etiquetas de mapa blanco hueso #E8E8E8

### DIFF
--- a/index.html
+++ b/index.html
@@ -274,9 +274,9 @@
       margin: -1px;
       filter: brightness(1.1) contrast(1.05);
     }
-    /* Etiquetas off-white sedoso (#CCCCCC aprox) — sin invert agresivo */
+    /* Etiquetas blanco hueso ~#E8E8E8: invert(negro→blanco) + brightness(0.91) */
     .map-labels-layer img {
-      filter: brightness(0.78) contrast(0.85) !important;
+      filter: invert(1) brightness(0.91) grayscale(1) !important;
     }
     .leaflet-container { background: #000 !important; }
     #open-full-report {

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -799,8 +799,8 @@ function openFullReport() {
         maxZoom: 20,
         crossOrigin: 'anonymous',
       }).addTo(rmap);
-      // Etiquetas: dark_only_labels → off-white suave vía CSS
-      L.tileLayer('https://{s}.basemaps.cartocdn.com/dark_only_labels/{z}/{x}/{y}{r}.png', {
+      // Etiquetas: light_only_labels (negras) → invert CSS → blanco hueso #E8E8E8
+      L.tileLayer('https://{s}.basemaps.cartocdn.com/light_only_labels/{z}/{x}/{y}{r}.png', {
         maxZoom: 20,
         crossOrigin: 'anonymous',
         className: 'map-labels-layer',

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -88,8 +88,8 @@ export function initMap(containerId, callbacks = {}) {
     maxZoom: 19,
     opacity: 0.85,
   }).addTo(_map);
-  // Etiquetas: dark_only_labels (ya son claras sobre transparente) → filtro suave → off-white
-  L.tileLayer('https://{s}.basemaps.cartocdn.com/dark_only_labels/{z}/{x}/{y}{r}.png', {
+  // Etiquetas: light_only_labels (negras sobre transparente) → invert CSS → blanco hueso #E8E8E8
+  L.tileLayer('https://{s}.basemaps.cartocdn.com/light_only_labels/{z}/{x}/{y}{r}.png', {
     subdomains: 'abcd',
     maxZoom: 19,
     className: 'map-labels-layer',


### PR DESCRIPTION
light_only_labels + invert(1) brightness(0.91) grayscale(1) = #E8E8E8 exacto. Legible, calido, integrado.