### PR TITLE
feat: Calculadora de Factibilidad en modal — autocompletado, precios por barrio, reset

### DIFF
--- a/index.html
+++ b/index.html
@@ -627,6 +627,90 @@
     }
 
 
+
+    /* ── CALCULADORA FACTIBILIDAD EN MODAL ──────────────────── */
+    .frm-calc-section {
+      background: #0a0a0a;
+      border: 1px solid #222;
+      border-radius: 8px;
+      padding: 24px 28px;
+      margin-bottom: 2rem;
+    }
+    .frm-calc-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      margin-bottom: 20px;
+    }
+    .frm-calc-title {
+      font-size: 9px; letter-spacing: 3px; text-transform: uppercase;
+      color: rgba(255,255,255,.28);
+    }
+    .frm-calc-reset {
+      font-size: 9px; letter-spacing: 2px; text-transform: uppercase;
+      color: rgba(200,169,110,.6); background: none; border: none;
+      cursor: pointer; padding: 4px 10px;
+      border: 1px solid rgba(200,169,110,.2); border-radius: 100px;
+      transition: all .2s;
+    }
+    .frm-calc-reset:hover { color: #C8A96E; border-color: rgba(200,169,110,.5); }
+
+    /* Grid de inputs */
+    .frm-calc-inputs {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+      gap: 12px;
+      margin-bottom: 20px;
+    }
+    .frm-calc-field { display: flex; flex-direction: column; gap: 6px; }
+    .frm-calc-label {
+      font-size: 9px; letter-spacing: 2px; text-transform: uppercase;
+      color: #C8A96E; font-weight: 400;
+    }
+    .frm-calc-input {
+      background: #111; border: 1px solid #333; border-radius: 4px;
+      padding: 10px 12px; color: #fff;
+      font-size: 14px; font-weight: 300;
+      font-family: 'Inter', inherit;
+      outline: none; transition: border-color .2s;
+      width: 100%; box-sizing: border-box;
+    }
+    .frm-calc-input:focus { border-color: rgba(200,169,110,.5); }
+    .frm-calc-input-hint {
+      font-size: 10px; color: rgba(255,255,255,.25); margin-top: 2px;
+    }
+
+    /* Resultados */
+    .frm-calc-results {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+      gap: 1px;
+      background: #222;
+      border: 1px solid #222;
+      border-radius: 6px;
+      overflow: hidden;
+    }
+    .frm-calc-result {
+      background: #0a0a0a;
+      padding: 16px 18px;
+    }
+    .frm-calc-result.highlight { background: #0f0a00; }
+    .frm-calc-result-label {
+      font-size: 9px; letter-spacing: 2px; text-transform: uppercase;
+      color: rgba(255,255,255,.35); margin-bottom: 8px;
+    }
+    .frm-calc-result-val {
+      font-size: 20px; font-weight: 200; color: #fff; line-height: 1;
+    }
+    .frm-calc-result.highlight .frm-calc-result-val { color: #C8A96E; }
+    .frm-calc-result-sub {
+      font-size: 10px; color: rgba(255,255,255,.3); margin-top: 4px;
+    }
+    .frm-calc-nota {
+      font-size: 10px; color: rgba(255,255,255,.2);
+      margin-top: 14px; font-style: italic; line-height: 1.5;
+    }
+
     </style></defs>
       <path class="av2" d="M80,50 L500,38 L545,100 L560,240 L540,380 L510,490 L455,590 L360,650 L240,658 L140,620 L80,550 L45,420 L35,260 L55,130 Z" opacity=".45"/>
       <path d="M500,38 L545,100 L560,240 L540,380 L510,490 L455,590" stroke="#fff" stroke-width=".3" fill="none" opacity=".1" stroke-dasharray="5,4"/>
@@ -1007,6 +1091,65 @@
         <div class="frm-analysis-card" style="grid-column:span 2">
           <div class="frm-table-title">⬡ Análisis de Enrase (Completamiento de Tejido)</div>
           <div id="frm-enrase-contenido"></div>
+        </div>
+      </div>
+
+      <!-- CALCULADORA DE FACTIBILIDAD -->
+      <div class="frm-calc-section">
+        <div class="frm-calc-header">
+          <div class="frm-calc-title">Simulador de Factibilidad Económica</div>
+          <button class="frm-calc-reset" id="frm-calc-reset-btn">↺ Restaurar valores</button>
+        </div>
+
+        <div class="frm-calc-inputs">
+          <div class="frm-calc-field">
+            <label class="frm-calc-label">M² Vendibles</label>
+            <input class="frm-calc-input" id="fc-m2-vendibles" type="number" placeholder="0">
+            <div class="frm-calc-input-hint">Arrastrado del cálculo normativo</div>
+          </div>
+          <div class="frm-calc-field">
+            <label class="frm-calc-label">Costo de Obra (USD/m²)</label>
+            <input class="frm-calc-input" id="fc-costo-obra" type="number" placeholder="1100">
+            <div class="frm-calc-input-hint" id="fc-costo-hint">Estimado por altura</div>
+          </div>
+          <div class="frm-calc-field">
+            <label class="frm-calc-label">Precio de Venta (USD/m²)</label>
+            <input class="frm-calc-input" id="fc-precio-venta" type="number" placeholder="2500">
+            <div class="frm-calc-input-hint" id="fc-precio-hint">Referencia del barrio</div>
+          </div>
+          <div class="frm-calc-field">
+            <label class="frm-calc-label">Gastos y Honorarios (%)</label>
+            <input class="frm-calc-input" id="fc-gastos" type="number" placeholder="15" min="0" max="50">
+            <div class="frm-calc-input-hint">Sobre el costo total de obra</div>
+          </div>
+        </div>
+
+        <div class="frm-calc-results" id="fc-results">
+          <div class="frm-calc-result">
+            <div class="frm-calc-result-label">Costo Total Construcción</div>
+            <div class="frm-calc-result-val" id="fc-r-costo">—</div>
+            <div class="frm-calc-result-sub" id="fc-r-costo-sub"></div>
+          </div>
+          <div class="frm-calc-result">
+            <div class="frm-calc-result-label">Ingresos por Ventas (GDV)</div>
+            <div class="frm-calc-result-val" id="fc-r-gdv">—</div>
+            <div class="frm-calc-result-sub" id="fc-r-gdv-sub"></div>
+          </div>
+          <div class="frm-calc-result highlight">
+            <div class="frm-calc-result-label">Ganancia Bruta Estimada</div>
+            <div class="frm-calc-result-val" id="fc-r-ganancia">—</div>
+            <div class="frm-calc-result-sub" id="fc-r-ganancia-sub"></div>
+          </div>
+          <div class="frm-calc-result highlight">
+            <div class="frm-calc-result-label">Incidencia Máx. Terreno</div>
+            <div class="frm-calc-result-val" id="fc-r-incidencia">—</div>
+            <div class="frm-calc-result-sub">USD/m² vendible</div>
+          </div>
+        </div>
+
+        <div class="frm-calc-nota">
+          * Simulación preliminar. No incluye costo del terreno. Honorarios profesionales sobre costo de obra.
+          Verificar con desarrollador.
         </div>
       </div>
 

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -820,6 +820,8 @@ function openFullReport() {
   ].filter(Boolean).join('\n');
   modal.classList.remove('hidden');
   document.body.style.overflow = 'hidden';
+  // Inicializar calculadora con valores de la parcela
+  setTimeout(() => initFeasCalc(), 60);
 
   // Mostrar botón PDF (fijo en la esquina superior del modal)
   const dlBtn = document.getElementById('btn-download-pdf');
@@ -1313,3 +1315,137 @@ function mostrarEnrase(res) {
 }
 // ── FIN MÓDULO ENRASE ─────────────────────────────────────────────
 
+
+
+
+// ── CALCULADORA FACTIBILIDAD EN MODAL ────────────────────────────
+// Precios de venta por barrio (USD/m²) — Zonaprop scraping 2025
+const PRECIOS_BARRIO = {"Palermo": 3503, "Belgrano": 3439, "Núñez": 3634, "Recoleta": 3231, "Caballito": 2569, "Villa Urquiza": 2676, "Villa Devoto": 2767, "Villa Crespo": 2597, "Almagro": 2433, "Flores": 2146, "Saavedra": 2616, "Palermo Hollywood": 3277, "Colegiales": 2787, "Las Cañitas": 3789, "Puerto Madero": 5515, "Balvanera": 2157, "Barrio Norte": 2711, "Villa del Parque": 2488, "Coghlan": 2652, "Palermo Chico": 4650, "Palermo Soho": 3262, "Belgrano R": 3476, "Boedo": 2067, "Barracas": 2085, "Monserrat": 1971, "San Cristobal": 2039, "Villa Luro": 2244, "San Telmo": 2346, "Mataderos": 2040, "Villa Ortuzar": 2786, "Chacarita": 2535, "Villa Santa Rita": 2104, "Villa Pueyrredón": 2334, "Caballito Sur": 2937, "Congreso": 1938, "Retiro": 2995, "Liniers": 2161, "La Paternal": 2016, "Floresta": 1809, "Palermo Nuevo": 4091, "Belgrano C": 3617, "Centro / Microcentro": 2164, "San Nicolás": 2068, "Caballito Norte": 2899, "Constitución": 1582, "Villa Lugano": 2151, "Parque Chas": 2272, "Monte Castro": 2260, "Botánico": 3626, "Parque Patricios": 1955, "Palermo Viejo": 2880, "Parque Chacabuco": 2361, "Flores Norte, Flores": 1996, "Once": 1685, "Belgrano Chico": 3460, "Villa General Mitre": 2365, "Abasto": 2316, "Parque Centenario": 2305, "Barrio Chino": 2572, "Velez Sarsfield": 2040};
+
+// Costo de construcción tiered por pisos (de feasibility.py)
+function getCostoObra(pisos) {
+  if (pisos <= 3)  return 1050;
+  if (pisos <= 7)  return 1300;
+  if (pisos <= 12) return 1550;
+  return 1800;
+}
+
+// Valores por defecto — se sobreescriben al abrir el informe
+let _fcDefaults = {
+  m2Vendibles: 0,
+  costoObra: 1100,
+  precioVenta: 2500,
+  gastos: 15,
+};
+
+function initFeasCalc() {
+  const pd     = window._currentParcelData;
+  const barrio = pd?.barrio || '';
+  const pisos  = window._pisosEstimados || 0;
+
+  // M² vendibles: del cálculo normativo
+  const m2v = parseFloat(document.getElementById('full-total')?.innerText) ||
+              window._finMetrosVendibles || 0;
+
+  // Costo obra tiered por pisos
+  const costoObra = pisos > 0 ? getCostoObra(pisos) : 1100;
+
+  // Precio de venta: buscar en tabla por barrio
+  let precioVenta = 2500; // fallback
+  if (barrio) {
+    // Buscar match parcial en la tabla
+    const key = Object.keys(PRECIOS_BARRIO).find(k =>
+      barrio.toLowerCase().includes(k.toLowerCase()) ||
+      k.toLowerCase().includes(barrio.toLowerCase())
+    );
+    if (key) precioVenta = PRECIOS_BARRIO[key];
+  }
+
+  _fcDefaults = { m2Vendibles: m2v, costoObra, precioVenta, gastos: 15 };
+
+  // Setear los inputs
+  const setVal = (id, val) => { const el = document.getElementById(id); if (el) el.value = val || ''; };
+  setVal('fc-m2-vendibles', Math.round(m2v) || '');
+  setVal('fc-costo-obra',   costoObra);
+  setVal('fc-precio-venta', precioVenta);
+  setVal('fc-gastos',       15);
+
+  // Hints
+  const hintCosto = document.getElementById('fc-costo-hint');
+  if (hintCosto && pisos > 0) hintCosto.textContent = `Estimado: ${pisos} pisos → USD ${costoObra}/m²`;
+
+  const hintPrecio = document.getElementById('fc-precio-hint');
+  if (hintPrecio) {
+    const key = Object.keys(PRECIOS_BARRIO).find(k =>
+      barrio.toLowerCase().includes(k.toLowerCase()) ||
+      k.toLowerCase().includes(barrio.toLowerCase())
+    );
+    hintPrecio.textContent = key
+      ? `Ref. ${key}: USD ${precioVenta}/m²`
+      : 'Referencia general';
+  }
+
+  // Bindear eventos (event delegation en la sección)
+  const section = document.querySelector('.frm-calc-section');
+  if (section && !section._fcBound) {
+    section.addEventListener('input', e => {
+      if (e.target.classList.contains('frm-calc-input')) recalcFeas();
+    });
+    section._fcBound = true;
+  }
+
+  // Botón reset
+  const resetBtn = document.getElementById('frm-calc-reset-btn');
+  if (resetBtn && !resetBtn._fcBound) {
+    resetBtn.addEventListener('click', () => {
+      setVal('fc-m2-vendibles', Math.round(_fcDefaults.m2Vendibles) || '');
+      setVal('fc-costo-obra',   _fcDefaults.costoObra);
+      setVal('fc-precio-venta', _fcDefaults.precioVenta);
+      setVal('fc-gastos',       _fcDefaults.gastos);
+      recalcFeas();
+    });
+    resetBtn._fcBound = true;
+  }
+
+  recalcFeas();
+}
+
+function recalcFeas() {
+  const getN = id => parseFloat(document.getElementById(id)?.value) || 0;
+  const m2v       = getN('fc-m2-vendibles');
+  const costoM2   = getN('fc-costo-obra');
+  const precioM2  = getN('fc-precio-venta');
+  const gastosPct = getN('fc-gastos') / 100;
+
+  const fmtUSD = n => 'USD ' + Math.round(n).toLocaleString('es-AR');
+  const set = (id, val) => { const el = document.getElementById(id); if (el) el.innerText = val; };
+  const setSub = (id, val) => { const el = document.getElementById(id); if (el) el.innerText = val; };
+
+  if (!m2v || !costoM2) {
+    ['fc-r-costo','fc-r-gdv','fc-r-ganancia','fc-r-incidencia'].forEach(id => set(id, '—'));
+    return;
+  }
+
+  // Cálculo
+  const costoBase   = m2v * costoM2;
+  const gastos      = costoBase * gastosPct;
+  const costoTotal  = costoBase + gastos;
+  const gdv         = precioM2 ? m2v * precioM2 : null;
+  const ganancia    = gdv ? gdv - costoTotal : null;
+  const margenPct   = gdv ? (ganancia / gdv * 100) : null;
+  // Incidencia máx: GDV - costoTotal - target 10% ROI
+  const targetROI   = costoTotal * 0.10;
+  const incidMax    = gdv ? Math.max(0, (gdv - costoTotal - targetROI) / m2v) : null;
+
+  set('fc-r-costo', fmtUSD(costoTotal));
+  setSub('fc-r-costo-sub', `Base ${fmtUSD(costoBase)} + honorarios ${fmtUSD(gastos)}`);
+
+  set('fc-r-gdv', gdv ? fmtUSD(gdv) : '—');
+  setSub('fc-r-gdv-sub', gdv ? `${Math.round(m2v).toLocaleString('es-AR')} m² × USD ${Math.round(precioM2)}` : 'Ingresá precio de venta');
+
+  set('fc-r-ganancia', ganancia != null ? fmtUSD(ganancia) : '—');
+  setSub('fc-r-ganancia-sub', margenPct != null ? `Margen: ${margenPct.toFixed(1)}%` : '');
+
+  set('fc-r-incidencia', incidMax != null ? fmtUSD(incidMax) : '—');
+}
+// ── FIN CALCULADORA FACTIBILIDAD ──────────────────────────────────


### PR DESCRIPTION
## Qué agrega

Sección de simulador financiero integrado en el modal de informe completo.

### Autocompletado al abrir el informe
- **M² vendibles**: se arrastra de `full-total` (el cálculo normativo)
- **Costo de obra**: tiered por pisos según `feasibility.py` (3p=1050, 7p=1300, 12p=1550, +12=1800)
- **Precio de venta**: tabla de 60 barrios reales de Zonaprop scraping (`precios_depto_nuevo.json`)
- **Gastos/honorarios**: 15% por defecto

### Campos editables
4 inputs con estilo oscuro y borde sutil. Al modificar cualquier campo → recálculo instantáneo.

### Resultados en tiempo real
- Costo total construcción (base + honorarios)
- Ingresos GDV
- **Ganancia bruta** (en dorado)
- **Incidencia máxima del terreno** (USD/m² vendible, en dorado) — el dato clave para desarrolladores

### Botón "↺ Restaurar valores"
Vuelve a los defaults de la parcela actual.

### Para el PDF
`recalcFeas()` escribe en el DOM — al hacer screenshot para PDF captura los valores actuales del usuario.

cc @juanwisz