### PR TITLE
feat: indicadores macro en vivo — dólar blue + UVA (dolarapi.com)

### DIFF
--- a/index.html
+++ b/index.html
@@ -711,6 +711,47 @@
       margin-top: 14px; font-style: italic; line-height: 1.5;
     }
 
+
+    /* ── INDICADORES MACRO ──────────────────────────────────── */
+    .frm-macro-bar {
+      display: flex;
+      align-items: center;
+      gap: 24px;
+      padding: 12px 18px;
+      background: rgba(255,255,255,.03);
+      border: 1px solid #1e1e1e;
+      border-radius: 6px;
+      margin-bottom: 16px;
+      flex-wrap: wrap;
+    }
+    .frm-macro-indicator {
+      display: flex; align-items: center; gap: 8px;
+    }
+    .frm-macro-label {
+      font-size: 10px; letter-spacing: 1.5px; text-transform: uppercase;
+      color: rgba(255,255,255,.35);
+    }
+    .frm-macro-val {
+      font-size: 13px; font-weight: 300; color: #fff;
+    }
+    .frm-macro-sep {
+      width: 1px; height: 16px;
+      background: rgba(255,255,255,.08);
+    }
+    .frm-macro-live {
+      display: flex; align-items: center; gap: 5px;
+      font-size: 9px; letter-spacing: 2px; text-transform: uppercase;
+    }
+    .frm-macro-dot {
+      width: 6px; height: 6px; border-radius: 50%;
+      background: #4ade80;
+      box-shadow: 0 0 4px rgba(74,222,128,.6);
+      animation: frm-pulse 2s infinite;
+    }
+    .frm-macro-dot.manual { background: #C8A96E; box-shadow: 0 0 4px rgba(200,169,110,.6); animation: none; }
+    .frm-macro-live-label { color: rgba(255,255,255,.3); }
+    @keyframes frm-pulse { 0%,100%{opacity:1} 50%{opacity:.4} }
+
     </style></defs>
       <path class="av2" d="M80,50 L500,38 L545,100 L560,240 L540,380 L510,490 L455,590 L360,650 L240,658 L140,620 L80,550 L45,420 L35,260 L55,130 Z" opacity=".45"/>
       <path d="M500,38 L545,100 L560,240 L540,380 L510,490 L455,590" stroke="#fff" stroke-width=".3" fill="none" opacity=".1" stroke-dasharray="5,4"/>
@@ -1099,6 +1140,25 @@
         <div class="frm-calc-header">
           <div class="frm-calc-title">Simulador de Factibilidad Económica</div>
           <button class="frm-calc-reset" id="frm-calc-reset-btn">↺ Restaurar valores</button>
+        </div>
+
+        <!-- Indicadores macro en vivo -->
+        <div class="frm-macro-bar" id="fc-macro-bar">
+          <div class="frm-macro-indicator">
+            <span class="frm-macro-label">💵 Dólar Blue</span>
+            <span class="frm-macro-val" id="fc-dolar-val">—</span>
+            <span class="frm-macro-label" style="font-size:9px;opacity:.6">(venta)</span>
+          </div>
+          <div class="frm-macro-sep"></div>
+          <div class="frm-macro-indicator">
+            <span class="frm-macro-label">📈 UVA</span>
+            <span class="frm-macro-val" id="fc-uva-val">—</span>
+          </div>
+          <div class="frm-macro-sep"></div>
+          <div class="frm-macro-live" id="fc-live-status">
+            <div class="frm-macro-dot" id="fc-live-dot"></div>
+            <span class="frm-macro-live-label" id="fc-live-label">EN VIVO</span>
+          </div>
         </div>
 
         <div class="frm-calc-inputs">

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -1339,6 +1339,9 @@ let _fcDefaults = {
 };
 
 function initFeasCalc() {
+  // Cargar indicadores macro en tiempo real
+  fetchMacroIndicators();
+
   const pd     = window._currentParcelData;
   const barrio = pd?.barrio || '';
   const pisos  = window._pisosEstimados || 0;
@@ -1468,3 +1471,77 @@ function recalcFeas() {
   set('fc-r-incidencia', incidMax != null ? fmtUSD(incidMax) : '—');
 }
 // ── FIN CALCULADORA FACTIBILIDAD ──────────────────────────────────
+
+
+// ── INDICADORES MACRO EN VIVO ─────────────────────────────────────
+const FC_FALLBACK_DOLAR = 1410;
+const FC_FALLBACK_UVA   = 1100;
+
+let _fcDolarBlue = FC_FALLBACK_DOLAR;
+let _fcUVA       = FC_FALLBACK_UVA;
+let _fcMacroLive = false;
+
+async function fetchMacroIndicators() {
+  const fmtARS = n => '$' + Math.round(n).toLocaleString('es-AR');
+  const setDolar = (val, live) => {
+    const el = document.getElementById('fc-dolar-val');
+    if (el) el.textContent = fmtARS(val);
+    _fcDolarBlue = val;
+  };
+  const setUVA = (val) => {
+    const el = document.getElementById('fc-uva-val');
+    if (el) el.textContent = fmtARS(val);
+    _fcUVA = val;
+  };
+  const setStatus = (live, msg) => {
+    const dot   = document.getElementById('fc-live-dot');
+    const label = document.getElementById('fc-live-label');
+    if (dot)   dot.className   = 'frm-macro-dot' + (live ? '' : ' manual');
+    if (label) label.textContent = msg;
+    _fcMacroLive = live;
+  };
+
+  // Mostrar fallback mientras carga
+  setDolar(FC_FALLBACK_DOLAR, false);
+  setUVA(FC_FALLBACK_UVA);
+  setStatus(false, 'CARGANDO...');
+
+  try {
+    const [rDolar, rUVA] = await Promise.allSettled([
+      fetch('https://dolarapi.com/v1/dolares/blue'),
+      fetch('https://dolarapi.com/v1/cotizaciones/uva'),
+    ]);
+
+    let dolarOk = false, uvaOk = false;
+
+    if (rDolar.status === 'fulfilled' && rDolar.value.ok) {
+      const d = await rDolar.value.json();
+      const venta = d.venta || d.value || FC_FALLBACK_DOLAR;
+      setDolar(venta, true);
+      dolarOk = true;
+    }
+
+    if (rUVA.status === 'fulfilled' && rUVA.value.ok) {
+      const d = await rUVA.value.json();
+      const val = d.valor || d.value || d.venta || FC_FALLBACK_UVA;
+      setUVA(val);
+      uvaOk = true;
+    }
+
+    if (dolarOk && uvaOk) {
+      setStatus(true, 'EN VIVO');
+    } else if (dolarOk || uvaOk) {
+      setStatus(false, 'PARCIAL');
+    } else {
+      setStatus(false, 'REF. MANUAL');
+    }
+
+  } catch(e) {
+    setStatus(false, 'VALORES DE REFERENCIA');
+  }
+}
+
+// Cuando el usuario modifica el dólar manualmente (no hay campo directo,
+// pero si modifica los inputs de costo/precio, el indicador sigue EN VIVO)
+// Si en el futuro se agrega un input de dólar, bindearlo aquí.
+// ── FIN INDICADORES MACRO ─────────────────────────────────────────


### PR DESCRIPTION
## Qué agrega

Barra de contexto macroeconómico en tiempo real, encima de los campos del simulador.

### Fuentes
- **Dólar Blue**: `dolarapi.com/v1/dolares/blue` → campo `venta`
- **UVA**: `dolarapi.com/v1/cotizaciones/uva` → campo `valor`

### Indicador visual
- `● EN VIVO` (dot verde animado) — ambas APIs respondieron OK
- `● PARCIAL` (dot dorado) — solo una respondió
- `● VALORES DE REFERENCIA` (dot dorado sin animación) — fallback manual

### Fallback
- Dólar: $1.410 / UVA: $1.100
- Se muestra mientras carga y si las APIs fallan

### Comportamiento
- Se llama al abrir el informe (`initFeasCalc()`)
- `Promise.allSettled()` — si una API falla la otra sigue
- No bloquea el render del informe

cc @juanwisz