### PR TITLE
feat: Layout Structural v4 — hero unificado, calc 6col, chat nativo, stretch

### DIFF
--- a/index.html
+++ b/index.html
@@ -1191,6 +1191,178 @@
     }
     /* ══ FIN CSS AUDIT ════════════════════════════════════════════ */
 
+
+    /* ══ LAYOUT STRUCTURAL v4 ════════════════════════════════════ */
+
+    /* ── 1. HERO ROW — card única dirección + mapa alineados ──── */
+    .frm-hero-row {
+      display: grid !important;
+      grid-template-columns: 1fr auto !important;
+      align-items: center !important;
+      gap: 0 !important;
+      background: linear-gradient(145deg, #1c1c1c 0%, #0d0d0d 100%) !important;
+      border: 1px solid rgba(255,255,255,.06) !important;
+      border-top: 1px solid rgba(255,255,255,.09) !important;
+      border-radius: 16px !important;
+      box-shadow: 0 8px 32px rgba(0,0,0,.5) !important;
+      padding: 28px 32px !important;
+      margin-bottom: 20px !important;
+      overflow: hidden !important;
+    }
+    .frm-hero-left {
+      background: transparent !important;
+      border: none !important;
+      box-shadow: none !important;
+      border-radius: 0 !important;
+      padding: 0 !important;
+    }
+    .frm-hero-right {
+      background: transparent !important;
+      border: none !important;
+      box-shadow: none !important;
+      border-radius: 0 !important;
+      padding: 0 !important;
+      margin-left: 32px !important;
+    }
+
+    /* ── 2. CALCULADORA — grilla 6 columnas exactas ──────────── */
+    .frm-calc-inputs {
+      display: grid !important;
+      grid-template-columns: repeat(6, 1fr) !important;
+      gap: 10px !important;
+      align-items: start !important;
+    }
+    .frm-calc-field {
+      display: flex !important;
+      flex-direction: column !important;
+      gap: 6px !important;
+    }
+    .frm-calc-input {
+      height: 44px !important;
+      line-height: 44px !important;
+      padding: 0 12px !important;
+      box-sizing: border-box !important;
+      width: 100% !important;
+    }
+    /* Resultados: valor centrado */
+    .frm-calc-result-val {
+      text-align: center !important;
+    }
+    .frm-calc-result-sub { display: none !important; }
+    .frm-calc-input-hint { display: none !important; }
+
+    /* ── 3. CHAT — misma altura que el cuerpo, sin empujar ────── */
+    .frm-with-chat {
+      display: flex !important;
+      align-items: stretch !important;
+    }
+    .frm-main-col {
+      flex: 1 !important;
+      min-width: 0 !important;
+    }
+    #report-chat-container {
+      width: 260px !important;
+      flex-shrink: 0 !important;
+      background: #111 !important;
+      backdrop-filter: none !important;
+      border-left: 1px solid #2a2a2a !important;
+      align-self: stretch !important;
+      position: sticky !important;
+      top: 0 !important;
+      height: 100vh !important;
+    }
+    .rc-msg.user {
+      background: transparent !important;
+      border-radius: 0 !important;
+      padding: 5px 0 5px 10px !important;
+      border-left: 2px solid rgba(200,169,110,.4) !important;
+      color: rgba(255,255,255,.9) !important;
+    }
+    .rc-msg.assistant {
+      background: transparent !important;
+      border-radius: 0 !important;
+      padding: 5px 0 !important;
+      color: rgba(180,180,180,.8) !important;
+    }
+    #rc-messages { scrollbar-width: none !important; -ms-overflow-style: none !important; }
+    #rc-messages::-webkit-scrollbar { display: none !important; }
+
+    /* ── 4. ANALYSIS — misma altura con stretch ─────────────── */
+    .frm-analysis {
+      display: grid !important;
+      grid-template-columns: 1fr 1fr !important;
+      gap: 20px !important;
+      align-items: stretch !important;
+      margin-bottom: 20px !important;
+    }
+    .frm-analysis-card {
+      display: flex !important;
+      flex-direction: column !important;
+    }
+
+    /* ── 5. PADDING ENTRE TARJETAS — que respire ─────────────── */
+    .frm-cards-row { margin-bottom: 20px !important; gap: 1px !important; }
+    .frm-table-card { margin-bottom: 20px !important; }
+    .frm-calc-section { margin-bottom: 20px !important; }
+    .frm-croquis { margin-bottom: 20px !important; }
+
+    /* Padding interno del cuerpo del informe */
+    .frm-body {
+      padding: 36px 40px 60px !important;
+    }
+
+    /* ── 6. MAPA — círculo gris plomo sin neón ─────────────── */
+    .frm-map-ring {
+      border: 1px solid #444 !important;
+      box-shadow: none !important;
+      outline: none !important;
+    }
+
+    /* ── 7. TARJETAS: cristal + border-top sutil ─────────────── */
+    .frm-card,
+    .frm-table-card,
+    .frm-analysis-card,
+    .frm-calc-section,
+    .frm-croquis {
+      background: linear-gradient(145deg, #1c1c1c 0%, #0d0d0d 100%) !important;
+      border: 1px solid rgba(255,255,255,.06) !important;
+      border-top: 1px solid rgba(255,255,255,.09) !important;
+      border-radius: 16px !important;
+      box-shadow: 0 6px 24px rgba(0,0,0,.45) !important;
+    }
+
+    /* ── 8. PLUSVALÍA — USD bold, UVA gris ─────────────────── */
+    .frm-plusvalia-usd {
+      font-size: 20px !important; font-weight: 600 !important;
+      color: #fff !important; display: block !important;
+    }
+    .frm-plusvalia-uva {
+      font-size: 10px !important; color: rgba(255,255,255,.3) !important;
+      display: inline !important; margin-left: 4px !important;
+    }
+
+    /* ── 9. BOTÓN PDF — glow amarillo ────────────────────── */
+    #btn-download-pdf {
+      animation: pdf-glow 3s ease-in-out infinite !important;
+    }
+    @keyframes pdf-glow {
+      0%,100% { box-shadow: 0 0 10px rgba(232,197,71,.2), 0 0 28px rgba(232,197,71,.06); }
+      50%      { box-shadow: 0 0 18px rgba(232,197,71,.4), 0 0 44px rgba(232,197,71,.14); }
+    }
+
+    /* ── Responsive ─────────────────────────────────────────── */
+    @media(max-width:1100px) {
+      .frm-calc-inputs { grid-template-columns: repeat(3, 1fr) !important; }
+    }
+    @media(max-width:700px) {
+      .frm-hero-row { grid-template-columns: 1fr !important; padding: 20px !important; }
+      .frm-hero-right { margin-left: 0 !important; margin-top: 16px !important; }
+      .frm-calc-inputs { grid-template-columns: repeat(2, 1fr) !important; }
+      .frm-body { padding: 20px !important; }
+      #report-chat-container { width: 100% !important; height: 320px !important; }
+    }
+    /* ══ FIN LAYOUT STRUCTURAL v4 ════════════════════════════════ */
+
     </style></defs>
       <path class="av2" d="M80,50 L500,38 L545,100 L560,240 L540,380 L510,490 L455,590 L360,650 L240,658 L140,620 L80,550 L45,420 L35,260 L55,130 Z" opacity=".45"/>
       <path d="M500,38 L545,100 L560,240 L540,380 L510,490 L455,590" stroke="#fff" stroke-width=".3" fill="none" opacity=".1" stroke-dasharray="5,4"/>


### PR DESCRIPTION
## Cambios estructurales de layout

### 1. Hero row — card única
- Dirección + mapa dentro del **mismo contenedor** con `border-radius: 16px`
- `grid-template-columns: 1fr auto` — dirección izq, mapa der, mismo eje horizontal
- Fondo grafito compartido, sin dos tarjetas separadas

### 2. Calculadora — grilla matemática
- `repeat(6, 1fr)` — 6 columnas exactamente iguales
- Todos los inputs `height: 44px`, `box-sizing: border-box`
- Valores de resultado centrados (`text-align: center`)
- Sub-textos y hints: `display: none`

### 3. Chat — integración nativa
- Mismo fondo que el cuerpo (`#111`)
- `border-left: 1px solid #2a2a2a` — sin barra blanca
- `align-self: stretch` — misma altura que el contenido
- Mensajes: timeline sin burbujas, scroll invisible

### 4. Analysis — stretch
- `align-items: stretch` — Plusvalía y Afectaciones con misma altura

### 5. Espaciado
- `padding: 36px 40px` en `frm-body` — el informe respira
- `margin-bottom: 20px` entre cada sección

### 6. Extras
- Mapa: `border: 1px solid #444` — sin neón
- Plusvalía: USD 20px bold blanco + UVA 10px gris inline
- PDF: glow pulse amarillo

cc @juanwisz