### PR TITLE
feat: Rigid Grid v6 — m² 4col, calc 6col, chat transparente, hero card única

### DIFF
--- a/index.html
+++ b/index.html
@@ -1702,6 +1702,234 @@
     }
     /* ══ FIN SEAMLESS v5 ══════════════════════════════════════════ */
 
+
+    /* ══ RIGID GRID v6 ════════════════════════════════════════════ */
+
+    /* ── HERO: un solo contenedor, dirección izq + mapa der ──── */
+    .frm-hero-row {
+      display: flex !important;
+      flex-direction: row !important;
+      align-items: center !important;
+      gap: 28px !important;
+      background: linear-gradient(145deg,#1c1c1c 0%,#0e0e0e 100%) !important;
+      border: 1px solid rgba(255,255,255,.07) !important;
+      border-top: 1px solid rgba(255,255,255,.1) !important;
+      border-radius: 16px !important;
+      box-shadow: 0 8px 32px rgba(0,0,0,.55) !important;
+      padding: 28px 32px !important;
+      margin-bottom: 20px !important;
+      overflow: hidden !important;
+    }
+    .frm-hero-left {
+      flex: 1 1 auto !important;
+      min-width: 0 !important;
+      background: transparent !important;
+      border: none !important;
+      box-shadow: none !important;
+      border-radius: 0 !important;
+      padding: 0 !important;
+      margin: 0 !important;
+    }
+    .frm-hero-right {
+      flex: 0 0 auto !important;
+      background: transparent !important;
+      border: none !important;
+      box-shadow: none !important;
+      border-radius: 0 !important;
+      padding: 0 !important;
+      margin: 0 !important;
+    }
+    /* Mapa: borde gris plomo, sin ningún neón */
+    .frm-map-ring {
+      border: 1.5px solid #3a3a3a !important;
+      box-shadow: none !important;
+      outline: none !important;
+    }
+
+    /* ── FILA m²: grilla matemática 4 columnas ──────────────── */
+    .frm-cards-row {
+      display: grid !important;
+      grid-template-columns: repeat(4, 1fr) !important;
+      gap: 20px !important;          /* espacio entre cards */
+      align-items: stretch !important;
+      margin-bottom: 20px !important;
+      background: transparent !important;
+    }
+    .frm-card {
+      display: flex !important;
+      flex-direction: column !important;
+      align-items: flex-start !important;
+      padding: 24px 24px !important;
+      background: linear-gradient(145deg,#1c1c1c 0%,#0d0d0d 100%) !important;
+      border: 1px solid rgba(255,255,255,.06) !important;
+      border-top: 1px solid rgba(255,255,255,.1) !important;
+      border-radius: 16px !important;
+      box-shadow: 0 4px 20px rgba(0,0,0,.45) !important;
+    }
+    .frm-card-label {
+      font-size: 9px !important;
+      letter-spacing: 2.5px !important;
+      text-transform: uppercase !important;
+      color: #C8A96E !important;
+      margin-bottom: 8px !important;
+    }
+    .frm-card-val {
+      font-size: clamp(1.8rem,3vw,2.8rem) !important;
+      font-weight: 200 !important;
+      color: #fff !important;
+      line-height: 1 !important;
+      text-align: left !important;
+    }
+    .frm-card.total .frm-card-val { color: #C8A96E !important; }
+    .frm-card-unit {
+      font-size: 11px !important;
+      color: rgba(255,255,255,.35) !important;
+      margin-top: 4px !important;
+    }
+
+    /* ── ANÁLISIS: stretch uniforme ─────────────────────────── */
+    .frm-analysis {
+      display: grid !important;
+      grid-template-columns: 1fr 1fr !important;
+      gap: 20px !important;
+      align-items: stretch !important;
+      margin-bottom: 20px !important;
+    }
+    .frm-analysis-card {
+      background: linear-gradient(145deg,#1c1c1c 0%,#0d0d0d 100%) !important;
+      border: 1px solid rgba(255,255,255,.06) !important;
+      border-top: 1px solid rgba(255,255,255,.1) !important;
+      border-radius: 16px !important;
+      box-shadow: 0 4px 20px rgba(0,0,0,.45) !important;
+      padding: 20px 24px !important;
+      display: flex !important;
+      flex-direction: column !important;
+    }
+
+    /* ── CALC: grilla 6 col exactas ─────────────────────────── */
+    .frm-calc-section {
+      background: linear-gradient(145deg,#1c1c1c 0%,#0d0d0d 100%) !important;
+      border: 1px solid rgba(255,255,255,.06) !important;
+      border-top: 1px solid rgba(255,255,255,.1) !important;
+      border-radius: 16px !important;
+      box-shadow: 0 4px 20px rgba(0,0,0,.45) !important;
+      padding: 24px 28px !important;
+      margin-bottom: 20px !important;
+    }
+    .frm-calc-inputs {
+      display: grid !important;
+      grid-template-columns: repeat(6,1fr) !important;
+      gap: 10px !important;
+      align-items: start !important;
+    }
+    .frm-calc-field { display: flex !important; flex-direction: column !important; gap: 5px !important; }
+    .frm-calc-input {
+      height: 44px !important;
+      line-height: 44px !important;
+      padding: 0 12px !important;
+      box-sizing: border-box !important;
+      width: 100% !important;
+      background: #111 !important;
+      border: 1px solid rgba(200,169,110,.3) !important;
+      border-radius: 6px !important;
+      color: #fff !important;
+      font-size: 13px !important;
+    }
+    .frm-calc-result-val { text-align: center !important; font-size: 18px !important; }
+    .frm-calc-result-sub { display: none !important; }
+    .frm-calc-input-hint { display: none !important; }
+
+    /* ── CHAT: fondo transparente, borderless ───────────────── */
+    .frm-with-chat { display: flex !important; align-items: stretch !important; }
+    .frm-main-col  { flex: 1 !important; min-width: 0 !important; overflow-y: auto !important; }
+
+    #report-chat-container {
+      width: 260px !important;
+      flex-shrink: 0 !important;
+      background: transparent !important;   /* FLOTAR sobre fondo negro */
+      border-left: 1px solid rgba(255,255,255,.06) !important;
+      align-self: stretch !important;
+      position: sticky !important;
+      top: 0 !important;
+      height: 100vh !important;
+    }
+    .rc-header {
+      background: transparent !important;
+      border-bottom: 1px solid rgba(255,255,255,.07) !important;
+    }
+    /* Timeline sin burbujas */
+    .rc-msg {
+      border-radius: 0 !important;
+      background: transparent !important;
+      padding: 5px 0 !important;
+      font-size: 12px !important;
+    }
+    .rc-msg.user {
+      color: rgba(255,255,255,.88) !important;
+      padding-left: 10px !important;
+      border-left: 2px solid rgba(200,169,110,.4) !important;
+    }
+    .rc-msg.assistant { color: rgba(175,175,175,.8) !important; }
+    .rc-msg.info { color: rgba(255,255,255,.22) !important; font-size: 10px !important; }
+    /* Input bar minimalista */
+    .rc-input-row { background: transparent !important; border-top: 1px solid rgba(255,255,255,.07) !important; }
+    .rc-input {
+      background: rgba(255,255,255,.04) !important;
+      border: 1px solid rgba(255,255,255,.1) !important;
+      color: #fff !important;
+    }
+    .rc-input:focus { border-color: rgba(200,169,110,.4) !important; outline: none !important; }
+    /* Scroll completamente invisible — todos los browsers */
+    #rc-messages { scrollbar-width: none !important; -ms-overflow-style: none !important; }
+    #rc-messages::-webkit-scrollbar { width: 0 !important; height: 0 !important; display: none !important; }
+
+    /* ── PLUSVALÍA: USD bold, UVA gris ──────────────────────── */
+    .frm-plusvalia-usd {
+      font-size: 20px !important; font-weight: 600 !important;
+      color: #fff !important; display: block !important;
+    }
+    .frm-plusvalia-uva {
+      font-size: 10px !important; color: rgba(255,255,255,.3) !important;
+      display: inline !important; margin-left: 4px !important;
+    }
+
+    /* ── TARJETAS GENERALES ──────────────────────────────────── */
+    .frm-table-card,
+    .frm-croquis {
+      background: linear-gradient(145deg,#1c1c1c 0%,#0d0d0d 100%) !important;
+      border: 1px solid rgba(255,255,255,.06) !important;
+      border-top: 1px solid rgba(255,255,255,.1) !important;
+      border-radius: 16px !important;
+      box-shadow: 0 4px 20px rgba(0,0,0,.45) !important;
+      margin-bottom: 20px !important;
+    }
+
+    /* ── CUERPO: padding generoso ────────────────────────────── */
+    .frm-body { padding: 36px 40px 64px !important; }
+
+    /* ── PDF glow ────────────────────────────────────────────── */
+    #btn-download-pdf { animation: pglow 3s ease-in-out infinite !important; }
+    @keyframes pglow {
+      0%,100% { box-shadow: 0 0 10px rgba(232,197,71,.2); }
+      50%      { box-shadow: 0 0 22px rgba(232,197,71,.45), 0 0 42px rgba(232,197,71,.12); }
+    }
+
+    /* ── Responsive ──────────────────────────────────────────── */
+    @media(max-width:1100px) {
+      .frm-cards-row { grid-template-columns: repeat(2,1fr) !important; }
+      .frm-calc-inputs { grid-template-columns: repeat(3,1fr) !important; }
+    }
+    @media(max-width:700px) {
+      .frm-cards-row { grid-template-columns: 1fr 1fr !important; gap:12px !important; }
+      .frm-hero-row  { flex-direction: column !important; padding:20px !important; }
+      .frm-hero-right{ margin:16px 0 0 !important; }
+      .frm-analysis  { grid-template-columns: 1fr !important; }
+      .frm-calc-inputs { grid-template-columns: repeat(2,1fr) !important; }
+      #report-chat-container { width:100% !important; height:300px !important; position:static !important; border-left:none !important; border-top:1px solid rgba(255,255,255,.07) !important; }
+      .frm-body { padding: 20px 16px 40px !important; }
+    }
+    /* ══ FIN RIGID GRID v6 ════════════════════════════════════ */
+
     </style></defs>
       <path class="av2" d="M80,50 L500,38 L545,100 L560,240 L540,380 L510,490 L455,590 L360,650 L240,658 L140,620 L80,550 L45,420 L35,260 L55,130 Z" opacity=".45"/>
       <path d="M500,38 L545,100 L560,240 L540,380 L510,490 L455,590" stroke="#fff" stroke-width=".3" fill="none" opacity=".1" stroke-dasharray="5,4"/>


### PR DESCRIPTION
## Grilla rígida v6

### m² cards
`repeat(4, 1fr)` con `gap: 20px`, `padding: 24px` idéntico, borde dorado, números `text-align: left`.

### Hero
`display:flex` — dirección flex:1 + mapa flex:0 dentro del MISMO contenedor grafito. El borde rodea los dos.

### Calc 6 columnas
`repeat(6, 1fr)`, todos los inputs `height: 44px`, `box-sizing: border-box`, borde dorado sutil.

### Chat seamless
`background: transparent` — los mensajes flotan sobre el negro. `border-left: 1px solid rgba(255,255,255,.06)`. Scroll `width: 0 / display: none` en todos los browsers.

### Análisis stretch confirmado
`gap: 20px`, `align-items: stretch`, misma altura.

### Reorden: análisis arriba del simulador (confirmado del PR anterior)

cc @juanwisz