### PR TITLE
fix: CSS cleanup definitivo — eliminar 16 bloques acumulados

### DIFF
--- a/index.html
+++ b/index.html
@@ -239,7 +239,80 @@
     .enrase-nota{font-size:10px;color:rgba(255,255,255,.25);margin-top:8px;font-style:italic;line-height:1.4}
     .enrase-no{font-size:11px;color:rgba(255,255,255,.35);display:flex;align-items:center;gap:8px}
     .enrase-icon{font-size:16px;color:rgba(255,255,255,.2)}
-  </style>
+
+    /* ══════════════════════════════════════════════════════════
+       INFORME MODAL — CSS DEFINITIVO (reemplaza todos los anteriores)
+       ══════════════════════════════════════════════════════════ */
+
+    /* HERO: dirección + mapa en un único contenedor */
+    .frm-hero-row{display:flex;flex-direction:row;align-items:center;gap:28px;background:linear-gradient(145deg,#1c1c1c,#0e0e0e);border:1px solid rgba(255,255,255,.07);border-top:1px solid rgba(255,255,255,.1);border-radius:16px;box-shadow:0 8px 32px rgba(0,0,0,.55);padding:28px 32px;margin-bottom:20px;overflow:hidden}
+    .frm-hero-left{flex:1 1 auto;min-width:0;background:transparent!important;border:none!important;box-shadow:none!important;border-radius:0!important;padding:0!important;margin:0!important}
+    .frm-hero-right{flex:0 0 auto;background:transparent!important;border:none!important;box-shadow:none!important;border-radius:0!important;padding:0!important;margin:0!important}
+    .frm-map-ring{border:1.5px solid #3a3a3a!important;box-shadow:none!important;outline:none!important}
+
+    /* M² CARDS: grilla 4 columnas matemáticas */
+    .frm-cards-row{display:grid!important;grid-template-columns:repeat(4,1fr)!important;gap:20px!important;align-items:stretch!important;margin-bottom:20px!important;background:transparent!important;padding:0!important}
+    .frm-card{display:flex!important;flex-direction:column!important;align-items:flex-start!important;padding:24px!important;background:linear-gradient(145deg,#1c1c1c,#0d0d0d)!important;border:1px solid rgba(255,255,255,.06)!important;border-top:1px solid rgba(255,255,255,.1)!important;border-radius:16px!important;box-shadow:0 4px 20px rgba(0,0,0,.45)!important;margin:0!important}
+    .frm-card-val{font-size:clamp(1.8rem,3vw,2.8rem)!important;font-weight:200!important;color:#fff!important;line-height:1!important;text-align:left!important}
+    .frm-card.total .frm-card-val{color:#C8A96E!important}
+    .frm-card-label{font-size:9px!important;letter-spacing:2.5px!important;text-transform:uppercase!important;color:#C8A96E!important;margin-bottom:8px!important}
+    .frm-card-unit{font-size:11px!important;color:rgba(255,255,255,.35)!important;margin-top:4px!important}
+    .frm-card-sub{font-size:10px!important;color:rgba(255,255,255,.3)!important}
+
+    /* ANÁLISIS: dos columnas, misma altura */
+    .frm-analysis{display:grid!important;grid-template-columns:1fr 1fr!important;gap:20px!important;align-items:stretch!important;margin-bottom:20px!important}
+    .frm-analysis-card{background:linear-gradient(145deg,#1c1c1c,#0d0d0d)!important;border:1px solid rgba(255,255,255,.06)!important;border-top:1px solid rgba(255,255,255,.1)!important;border-radius:16px!important;box-shadow:0 4px 20px rgba(0,0,0,.45)!important;padding:20px 24px!important;display:flex!important;flex-direction:column!important}
+
+    /* CALC: 6 columnas exactas */
+    .frm-calc-section{background:linear-gradient(145deg,#1c1c1c,#0d0d0d)!important;border:1px solid rgba(255,255,255,.06)!important;border-top:1px solid rgba(255,255,255,.1)!important;border-radius:16px!important;box-shadow:0 4px 20px rgba(0,0,0,.45)!important;padding:24px 28px!important;margin-bottom:20px!important}
+    .frm-calc-inputs{display:grid!important;grid-template-columns:repeat(6,1fr)!important;gap:10px!important;align-items:start!important}
+    .frm-calc-field{display:flex!important;flex-direction:column!important;gap:5px!important}
+    .frm-calc-input{height:44px!important;padding:0 12px!important;box-sizing:border-box!important;width:100%!important;background:#111!important;border:1px solid rgba(200,169,110,.3)!important;border-radius:6px!important;color:#fff!important;font-size:13px!important;line-height:44px!important}
+    .frm-calc-result-val{text-align:center!important;font-size:18px!important}
+    .frm-calc-result-sub,.frm-calc-input-hint{display:none!important}
+    .frm-calc-results{border-radius:12px!important;overflow:hidden!important}
+    .frm-calc-result{background:linear-gradient(145deg,#161616,#0e0e0e)!important;border-top:1px solid rgba(255,255,255,.05)!important}
+    .frm-calc-result.highlight{background:linear-gradient(145deg,#1a1300,#0a0800)!important;border-top:1px solid rgba(200,169,110,.08)!important}
+
+    /* CHAT: transparente, sin scroll visible, borderless */
+    .frm-with-chat{display:flex!important;align-items:stretch!important}
+    .frm-main-col{flex:1!important;min-width:0!important;overflow-y:auto!important}
+    #report-chat-container{width:260px!important;flex-shrink:0!important;background:transparent!important;border-left:1px solid rgba(255,255,255,.05)!important;align-self:stretch!important;position:sticky!important;top:0!important;height:100vh!important}
+    .rc-header{background:transparent!important;border-bottom:1px solid rgba(255,255,255,.07)!important}
+    .rc-msg{border-radius:0!important;background:transparent!important;padding:5px 0!important;font-size:12px!important}
+    .rc-msg.user{color:rgba(255,255,255,.88)!important;padding-left:10px!important;border-left:2px solid rgba(200,169,110,.4)!important}
+    .rc-msg.assistant{color:rgba(175,175,175,.8)!important}
+    .rc-msg.info{color:rgba(255,255,255,.22)!important;font-size:10px!important}
+    .rc-input-row{background:transparent!important;border-top:1px solid rgba(255,255,255,.07)!important}
+    .rc-input{background:rgba(255,255,255,.04)!important;border:1px solid rgba(255,255,255,.1)!important;color:#fff!important}
+    .rc-input:focus{border-color:rgba(200,169,110,.4)!important;outline:none!important}
+    .rc-chips{background:transparent!important;border-top:1px solid rgba(255,255,255,.06)!important}
+    #rc-messages{scrollbar-width:none!important;-ms-overflow-style:none!important;overflow-y:auto!important}
+    #rc-messages::-webkit-scrollbar{width:0!important;height:0!important;display:none!important}
+
+    /* TARJETAS GENERALES */
+    .frm-table-card,.frm-croquis{background:linear-gradient(145deg,#1c1c1c,#0d0d0d)!important;border:1px solid rgba(255,255,255,.06)!important;border-top:1px solid rgba(255,255,255,.1)!important;border-radius:16px!important;box-shadow:0 4px 20px rgba(0,0,0,.45)!important;margin-bottom:20px!important}
+
+    /* PLUSVALÍA */
+    .frm-plusvalia-usd{font-size:20px!important;font-weight:600!important;color:#fff!important;display:block!important}
+    .frm-plusvalia-uva{font-size:10px!important;color:rgba(255,255,255,.3)!important;display:inline!important;margin-left:4px!important}
+
+    /* CUERPO Y ESPACIADO */
+    .frm-body{padding:36px 40px 64px!important}
+
+    /* BOTÓN PDF GLOW */
+    #btn-download-pdf{animation:pdffinal 3s ease-in-out infinite!important}
+    @keyframes pdffinal{0%,100%{box-shadow:0 0 10px rgba(232,197,71,.2)}50%{box-shadow:0 0 22px rgba(232,197,71,.45),0 0 40px rgba(232,197,71,.12)}}
+
+    /* RESPONSIVE */
+    @media(max-width:1100px){.frm-cards-row{grid-template-columns:repeat(2,1fr)!important}.frm-calc-inputs{grid-template-columns:repeat(3,1fr)!important}}
+    @media(max-width:700px){.frm-hero-row{flex-direction:column!important;padding:20px!important}.frm-hero-right{margin:16px 0 0!important}.frm-analysis{grid-template-columns:1fr!important}.frm-calc-inputs{grid-template-columns:repeat(2,1fr)!important}#report-chat-container{width:100%!important;height:300px!important;position:static!important;border-left:none!important;border-top:1px solid rgba(255,255,255,.07)!important}.frm-body{padding:20px 16px 40px!important}}
+
+    /* ══════════════════════════════════════════════════════════
+       FIN CSS DEFINITIVO
+       ══════════════════════════════════════════════════════════ */
+
+    </style>
 </head>
 <body>
 


### PR DESCRIPTION
16 bloques CSS del modal se contradecían entre sí incluso con !important. Este PR extrae el CSS base de la app y reemplaza todos los bloques por uno único y limpio.