### PR TITLE
fix: PR #158 — cache bust HTML, scrollbar atómico, grid m² fix

### DIFF
--- a/index.html
+++ b/index.html
@@ -290,6 +290,16 @@
     #rc-messages{scrollbar-width:none!important;-ms-overflow-style:none!important;overflow-y:auto!important}
     #rc-messages::-webkit-scrollbar{width:0!important;height:0!important;display:none!important}
 
+    /* SCROLLBAR ATÓMICO — oculta cualquier barra dentro del modal */
+    .formal-report ::-webkit-scrollbar{width:0!important;height:0!important;display:none!important}
+    .formal-report ::-webkit-scrollbar-track{display:none!important}
+    .formal-report ::-webkit-scrollbar-thumb{display:none!important}
+    .formal-report *{scrollbar-width:none!important;-ms-overflow-style:none!important}
+
+    /* M² GRID — fuerza 4 columnas sin margen residual */
+    .frm-cards-row{display:grid!important;grid-template-columns:repeat(4,1fr)!important;gap:20px!important;background:transparent!important;padding:0!important;margin:0 0 20px 0!important}
+    .frm-card{margin:0!important;padding:24px!important;background:linear-gradient(145deg,#1c1c1c,#0d0d0d)!important;border:1px solid rgba(255,255,255,.06)!important;border-top:1px solid rgba(255,255,255,.1)!important;border-radius:16px!important;box-shadow:0 4px 20px rgba(0,0,0,.45)!important;display:flex!important;flex-direction:column!important;align-items:flex-start!important}
+
     /* TARJETAS GENERALES */
     .frm-table-card,.frm-croquis{background:linear-gradient(145deg,#1c1c1c,#0d0d0d)!important;border:1px solid rgba(255,255,255,.06)!important;border-top:1px solid rgba(255,255,255,.1)!important;border-radius:16px!important;box-shadow:0 4px 20px rgba(0,0,0,.45)!important;margin-bottom:20px!important}
 
@@ -2085,6 +2095,16 @@
     #rc-messages{scrollbar-width:none!important;-ms-overflow-style:none!important;overflow-y:auto!important}
     #rc-messages::-webkit-scrollbar{width:0!important;height:0!important;display:none!important}
     .rc-chips{background:transparent!important;border-top:1px solid rgba(255,255,255,.06)!important}
+
+    /* SCROLLBAR ATÓMICO — oculta cualquier barra dentro del modal */
+    .formal-report ::-webkit-scrollbar{width:0!important;height:0!important;display:none!important}
+    .formal-report ::-webkit-scrollbar-track{display:none!important}
+    .formal-report ::-webkit-scrollbar-thumb{display:none!important}
+    .formal-report *{scrollbar-width:none!important;-ms-overflow-style:none!important}
+
+    /* M² GRID — fuerza 4 columnas sin margen residual */
+    .frm-cards-row{display:grid!important;grid-template-columns:repeat(4,1fr)!important;gap:20px!important;background:transparent!important;padding:0!important;margin:0 0 20px 0!important}
+    .frm-card{margin:0!important;padding:24px!important;background:linear-gradient(145deg,#1c1c1c,#0d0d0d)!important;border:1px solid rgba(255,255,255,.06)!important;border-top:1px solid rgba(255,255,255,.1)!important;border-radius:16px!important;box-shadow:0 4px 20px rgba(0,0,0,.45)!important;display:flex!important;flex-direction:column!important;align-items:flex-start!important}
 
     /* TARJETAS GENERALES */
     .frm-table-card,.frm-croquis{background:linear-gradient(145deg,#1c1c1c,#0d0d0d)!important;border:1px solid rgba(255,255,255,.06)!important;border-top:1px solid rgba(255,255,255,.1)!important;border-radius:16px!important;box-shadow:0 4px 20px rgba(0,0,0,.45)!important;margin-bottom:20px!important}

--- a/server.py
+++ b/server.py
@@ -1071,9 +1071,11 @@ class StaticFileFilterMiddleware(BaseHTTPMiddleware):
 
             return Response(status_code=404)
         response = await call_next(request)
-        # Prevent browser caching of JS/CSS so deploys take effect immediately
-        if ext in (".js", ".css"):
-            response.headers["Cache-Control"] = "no-cache, must-revalidate"
+        # Prevent browser caching of HTML/JS/CSS so deploys take effect immediately
+        if ext in (".html", ".js", ".css") or ext == "":
+            response.headers["Cache-Control"] = "no-cache, no-store, must-revalidate"
+            response.headers["Pragma"] = "no-cache"
+            response.headers["Expires"] = "0"
         return response
 
 


### PR DESCRIPTION
## Root cause

`server.py` solo enviaba `no-cache` para `.js`/`.css`. El HTML era cacheado por el browser → los cambios de CSS inline nunca llegaban.

## Fixes

- **server.py**: extiende `no-cache` a `.html` + root path `""` (triple header: Cache-Control + Pragma + Expires)
- **index.html**: scrollbar atómico `.formal-report *{scrollbar-width:none}` + `::-webkit-scrollbar{display:none}` en ambos bloques DEFINITIVO y v7
- **index.html**: `.frm-cards-row` y `.frm-card` con `margin:0!important` explícito en grid de 4 columnas

## Test plan
- [ ] Hard refresh (Ctrl+Shift+R) ya no necesario — CSS llega fresco en cada carga
- [ ] Sin barra de scroll blanca en el chat
- [ ] 4 tarjetas de m² perfectamente alineadas en grilla

🤖 Generated with [Claude Code](https://claude.com/claude-code)