### PR TITLE
fix: card-label height:45px — base de títulos alineada exactamente

### DIFF
--- a/index.html
+++ b/index.html
@@ -2688,43 +2688,44 @@
 
 
   <style>
-    /* ── NUCLEAR v2 — label height fix + card centering ── */
+    /* ── NUCLEAR v3 — label 45px height fija, base alineada ── */
 
-    /* Cards: flex column, centrado vertical */
+    /* Cards: flex column, space-between para respirar parejo */
     #full-report-modal .frm-card,
     #full-report-modal .frm-cards-row > div {
       display: flex !important;
       flex-direction: column !important;
-      justify-content: space-between !important;
+      justify-content: flex-start !important;
       align-items: center !important;
       text-align: center !important;
       min-height: 130px !important;
       padding: 20px 16px !important;
+      gap: 0 !important;
     }
 
-    /* Label: caja de altura fija alineada al fondo */
+    /* Label: CAJA DE 45px — texto anclado al fondo (flex-end)
+       Sin importar si el título tiene 1 o 2 líneas, la base
+       de todas las letras cae exactamente en la misma coordenada Y */
     #full-report-modal .frm-card-label {
       display: flex !important;
       align-items: flex-end !important;
       justify-content: center !important;
-      min-height: 36px !important;
-      height: 36px !important;
+      height: 45px !important;
+      min-height: 45px !important;
+      max-height: 45px !important;
       width: 100% !important;
       text-align: center !important;
       margin: 0 !important;
       padding: 0 !important;
       line-height: 1.2 !important;
+      overflow: hidden !important;
     }
 
-    /* Número: protagonista centrado */
+    /* Número: inmediatamente después del label, siempre alineado */
     #full-report-modal .frm-card-val {
       width: 100% !important;
       text-align: center !important;
-      margin: 8px 0 0 0 !important;
-      flex: 1 !important;
-      display: flex !important;
-      align-items: center !important;
-      justify-content: center !important;
+      margin: 10px 0 0 0 !important;
     }
 
     /* Unidad m² */


### PR DESCRIPTION
height:45px + align-items:flex-end garantiza que todos los títulos terminen en la misma coordenada Y, sin importar si tienen 1 o 2 líneas. Sin márgenes manuales.