### PR TITLE
fix: Análisis de Enrase — siempre visible, placeholder si null, CSS forzado

### DIFF
--- a/index.html
+++ b/index.html
@@ -2749,6 +2749,13 @@
       width: 0 !important;
     }
 
+    /* Enrase — texto siempre visible */
+    #full-report-modal #frm-enrase-bloque { display: block !important; color: rgba(255,255,255,.8) !important; }
+    #full-report-modal #frm-enrase-contenido { color: rgba(255,255,255,.8) !important; }
+    #full-report-modal #frm-enrase-contenido span { color: rgba(255,255,255,.8) !important; }
+    #full-report-modal .frm-analysis-item span:first-child { color: rgba(255,255,255,.45) !important; font-size: 11px !important; }
+    #full-report-modal .frm-analysis-item span:last-child { color: #fff !important; }
+
     /* Chat transparente */
     #full-report-modal #report-chat-container {
       background: transparent !important;


### PR DESCRIPTION
## Causa

El bloque `#frm-enrase-bloque` tenía `display:none` y la función en `openFullReport` solo lo mostraba si `enraseData` existía — si la API de linderos no respondió, quedaba vacío.

## Fixes

1. **JS**: `frmEnr.style.display = 'block'` siempre, independientemente de los datos
2. **Placeholder**: Si `enraseData` es null → "No aplica enrase para esta unidad edificable según normativa CUR."
3. **Si no aplica**: Muestra el `mensaje` explicativo (ej: "No aplica enrase: distrito USAB")
4. **CSS nuclear**: `color: rgba(255,255,255,.8)` forzado en `#frm-enrase-contenido` para que el texto no sea negro sobre negro