### PR TITLE
fix: causa raíz scroll — remover overflow:hidden del body en openFullReport

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -837,7 +837,8 @@ function openFullReport() {
     'Lote: '+getVal('c-sup')+'m²','Vendible: '+getText('full-total')+'m²'
   ].filter(Boolean).join('\n');
   modal.classList.remove('hidden');
-  document.body.style.overflow = 'hidden';
+  // El modal tiene su propio scroll — no bloquear el body
+  // document.body.style.overflow = 'hidden'; // REMOVIDO
   // Inicializar calculadora con valores de la parcela
   setTimeout(() => initFeasCalc(), 60);
 


### PR DESCRIPTION
La raíz del problema: `app.js` ejecutaba `document.body.style.overflow = 'hidden'` al abrir el modal, pisando el `overflow-y:scroll` del CSS y el inline style. Ahora el modal scrollea de forma independiente con su propio overflow.