### PR TITLE
fix: header unificado #frm-header — logo+PDF+X en flex sticky (#202)

### DIFF
--- a/index.html
+++ b/index.html
@@ -2412,24 +2412,32 @@
 
   <!-- FULL REPORT MODAL -->
   <div id="full-report-modal" class="formal-report hidden" style="position:fixed!important;top:0!important;left:0!important;width:calc(100% - 400px)!important;height:100vh!important;overflow-y:scroll!important;box-sizing:border-box!important;background:#000!important;z-index:9998!important;">
-    <button id="close-full-report" title="Cerrar">&times;</button>
 
-    <div class="frm-with-chat">
-    <div class="frm-main-col">
-      <!-- Botón PDF sticky dentro del panel principal — nunca superpone el chat -->
+    <!-- ── HEADER UNIFICADO: Logo + PDF + X en un solo flex sticky ── -->
+    <div id="frm-header">
+      <!-- Logo -->
+      <div class="frm-header-logo">
+        <div style="font-size:2.2rem;font-weight:200;letter-spacing:5px;text-transform:uppercase;line-height:1;color:#fff;display:flex;align-items:center">
+          <svg width="44" height="44" viewBox="0 0 44 44" xmlns="http://www.w3.org/2000/svg" style="margin-right:2px;vertical-align:middle;flex-shrink:0"><rect x="0.75" y="0.75" width="42.5" height="42.5" fill="none" stroke="rgba(255,255,255,.8)" stroke-width="1.5"/><path d="M14 10 L14 34 M14 10 L30 10 M14 22 L28 22 M14 34 L30 34" stroke="#fff" stroke-width="1.5" fill="none"/></svg>DIFIC<em style="color:var(--accent);font-style:normal">IA</em>
+        </div>
+        <small style="font-size:7px;text-transform:uppercase;color:#fff;font-weight:300;letter-spacing:4px;margin-top:3px;display:block">KAREN MARINI</small>
+      </div>
+      <!-- Spacer -->
+      <div style="flex:1"></div>
+      <!-- Botón PDF -->
       <div id="pdf-btn-wrap">
         <button id="btn-download-pdf" title="Descargar informe PDF">
           <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
           DESCARGAR PDF
         </button>
       </div>
-    <div class="frm-body">
+      <!-- Botón X cierre -->
+      <button id="close-full-report" title="Cerrar">&times;</button>
+    </div>
 
-      <!-- LOGO INSTITUCIONAL -->
-      <div style="display:flex;flex-direction:column;margin-bottom:40px">
-        <div style="font-size:2.2rem;font-weight:200;letter-spacing:5px;text-transform:uppercase;line-height:1;color:#fff;display:flex;align-items:center"><svg width="44" height="44" viewBox="0 0 44 44" xmlns="http://www.w3.org/2000/svg" style="margin-right:2px;vertical-align:middle"><rect x="0.75" y="0.75" width="42.5" height="42.5" fill="none" stroke="rgba(255,255,255,.8)" stroke-width="1.5"/><path d="M14 10 L14 34 M14 10 L30 10 M14 22 L28 22 M14 34 L30 34" stroke="#fff" stroke-width="1.5" fill="none"/></svg>DIFIC<em style="color:var(--accent);font-style:normal">IA</em></div>
-        <small style="font-size:7px;text-transform:uppercase;color:#fff;font-weight:300;letter-spacing:4px;margin-top:3px">KAREN MARINI</small>
-      </div>
+    <div class="frm-with-chat">
+    <div class="frm-main-col">
+    <div class="frm-body">
 
       <!-- MÓDULO HERO: dirección + mapa -->
       <div class="frm-hero-row">
@@ -2738,34 +2746,69 @@
     .frm-with-chat { display: block !important; }
     .frm-main-col  { display: block !important; width: 100% !important; }
 
-    /* PDF btn sticky */
-    #pdf-btn-wrap {
+    /* ── HEADER UNIFICADO #frm-header ── */
+    #frm-header {
       position: sticky !important;
       top: 0 !important;
-      z-index: 100 !important;
+      z-index: 10001 !important;
       display: flex !important;
-      justify-content: flex-end !important;
-      padding: 16px 20px 0 0 !important;
+      align-items: center !important;
+      padding: 0 20px 0 40px !important;
+      height: 72px !important;
       background: #000 !important;
+      border-bottom: 1px solid rgba(255,255,255,.07) !important;
+      box-sizing: border-box !important;
+      overflow: visible !important;
     }
 
-    /* LOGO: subir para alinearse con PDF btn sticky */
-    #full-report-modal .frm-body > div:first-child,
-    #formal-report-modal .frm-body > div:first-child {
-      margin-top: -60px !important;
-      padding-bottom: 20px !important;
+    /* Logo: altura libre, sin overflow hidden */
+    .frm-header-logo {
+      display: flex !important;
+      flex-direction: column !important;
+      justify-content: center !important;
+      height: auto !important;
+      overflow: visible !important;
+      flex-shrink: 0 !important;
     }
 
-    /* Botón X */
+    /* PDF btn: dentro del header, sin sticky propio */
+    #pdf-btn-wrap {
+      position: static !important;
+      display: flex !important;
+      align-items: center !important;
+      margin-right: 16px !important;
+      padding: 0 !important;
+      background: transparent !important;
+      flex-shrink: 0 !important;
+    }
+
+    /* Botón X: último elemento del flex, separado del PDF */
     #full-report-modal #close-full-report, #formal-report-modal #close-full-report {
-      position: fixed !important; top: 20px !important; right: 420px !important; z-index: 10001 !important;
-      background: rgba(0,0,0,0.7) !important; border: 1px solid #ffcc00 !important; border-radius: 50% !important;
-      width: 36px !important; height: 36px !important; display: flex !important;
-      align-items: center !important; justify-content: center !important;
-      font-size: 18px !important; color: #ffcc00 !important; cursor: pointer !important; padding: 0 !important;
+      position: static !important;
+      flex-shrink: 0 !important;
+      background: rgba(0,0,0,0.7) !important;
+      border: 1px solid #ffcc00 !important;
+      border-radius: 50% !important;
+      width: 36px !important;
+      height: 36px !important;
+      display: flex !important;
+      align-items: center !important;
+      justify-content: center !important;
+      font-size: 18px !important;
+      color: #ffcc00 !important;
+      cursor: pointer !important;
+      padding: 0 !important;
+      margin-left: 0 !important;
     }
     #full-report-modal #close-full-report:hover, #formal-report-modal #close-full-report:hover {
       background: rgba(255,204,0,.2) !important;
+    }
+
+    /* frm-body: sin margin-top negativo, el header ya ocupa su espacio */
+    #full-report-modal .frm-body > div:first-child,
+    #formal-report-modal .frm-body > div:first-child {
+      margin-top: 0 !important;
+      padding-bottom: 0 !important;
     }
 
     /* Chat fixed right */


### PR DESCRIPTION
## Problema
El header del informe modal tenía 3 elementos desconectados:
- Logo dentro de `frm-body` con `margin-top:-60px` para "subirse"
- `#pdf-btn-wrap` sticky flotando solo encima
- `#close-full-report` posicionado `fixed` encima del PDF btn

→ Logo cortado, X superpuesta al botón amarillo, sin alineación.

## Solución
Creé `#frm-header`: contenedor `sticky top:0` con `display:flex; align-items:center` que unifica los 3 elementos:
```
[Logo EDIFICIA / KAREN MARINI] — [flex:1 spacer] — [DESCARGAR PDF] — [× X]
```

### Cambios HTML
- Logo sacado de `frm-body` → movido a `#frm-header > .frm-header-logo`
- `#pdf-btn-wrap` movido dentro de `#frm-header` (ya no sticky propio)
- `#close-full-report` último elemento del flex (ya no `position:fixed`)

### Cambios CSS nuclear (antes de `</body>`)
- `#frm-header`: `sticky top:0`, `height:72px`, `padding:0 20px 0 40px`, `overflow:visible`
- `.frm-header-logo`: `height:auto !important`, `overflow:visible !important`
- `#pdf-btn-wrap`: `position:static`, `margin-right:16px`
- `#close-full-report`: `position:static` (ya no `fixed right:420px`)
- Removido: `margin-top:-60px` del primer hijo de `frm-body`

### Scroll preservado
`#full-report-modal` mantiene `overflow-y:scroll!important` en el inline style del div.

Closes #header-overflow-bug