### PR TITLE
fix(solar): normalize raw coord array to GeoJSON Feature

### DIFF
--- a/static/js/solar-ui.js
+++ b/static/js/solar-ui.js
@@ -33,6 +33,16 @@ export function initializeSolarModule(geometry, coords) {
     return;
   }
 
+  // La DB almacena polygon_geojson como array crudo de [lng, lat] pairs.
+  // Normalizar a GeoJSON Feature antes de pasarlo a computeSolarAnalysis.
+  if (Array.isArray(geometry)) {
+    geometry = {
+      type: 'Feature',
+      geometry: { type: 'Polygon', coordinates: [geometry] },
+      properties: {},
+    };
+  }
+
   try {
     const data = computeSolarAnalysis(geometry, coords);
     if (!data) {


### PR DESCRIPTION
polygon_geojson in DB is stored as raw [[lng,lat],...] array. detectFacadeOrientation expected a GeoJSON .type property, got undefined, returned null silently. Fix: wrap array -> Feature in initializeSolarModule.