### PR TITLE
Add observability: system metrics + chat turn timing

### DIFF
--- a/chat.py
+++ b/chat.py
@@ -547,11 +547,24 @@ async def create_sse_stream(
         await client.query(message)
         working = False
 
+        last_event_time = time.monotonic()
+        turn = 0
         async for msg in client.receive_response():
+            now = time.monotonic()
+            gap = now - last_event_time
+            last_event_time = now
+
             if isinstance(msg, AssistantMessage):
+                turn += 1
                 if msg.usage:
                     total_input_tokens += msg.usage.get("input_tokens", 0)
                     total_output_tokens += msg.usage.get("output_tokens", 0)
+                    logger.info(
+                        "chat_turn session=%s turn=%d gap=%.1fs in=%d out=%d",
+                        session_id[:8], turn, gap,
+                        msg.usage.get("input_tokens", 0),
+                        msg.usage.get("output_tokens", 0),
+                    )
 
                 has_text = False
                 has_tool = False

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ PyJWT==2.10.1
 requests==2.32.3
 claude-agent-sdk>=0.1.0
 httpx>=0.28.0,<1.0
+psutil

--- a/server.py
+++ b/server.py
@@ -526,6 +526,8 @@ def root() -> RedirectResponse:
 
 @app.get("/api/health")
 def health() -> dict[str, Any]:
+    import psutil
+
     with db_connect() as conn:
         total = conn.execute("SELECT COUNT(*) FROM parcelas").fetchone()[0]
         cur3d = conn.execute(
@@ -535,7 +537,35 @@ def health() -> dict[str, Any]:
             "SELECT COUNT(*) FROM parcelas WHERE COALESCE(epok_enriched, 0) = 1"
         ).fetchone()[0]
 
-    return {"ok": True, "total": total, "epok": epok, "cur3d": cur3d}
+    # System metrics
+    mem = psutil.virtual_memory()
+    swap = psutil.swap_memory()
+    proc = psutil.Process()
+    cli_procs = []
+    for child in proc.children(recursive=True):
+        try:
+            cmd = " ".join(child.cmdline())
+            if "claude" in cmd:
+                cli_procs.append({"pid": child.pid, "rss_mb": round(child.memory_info().rss / 1e6, 1), "status": child.status()})
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
+            pass
+
+    return {
+        "ok": True,
+        "total": total,
+        "epok": epok,
+        "cur3d": cur3d,
+        "system": {
+            "ram_total_mb": round(mem.total / 1e6),
+            "ram_used_mb": round(mem.used / 1e6),
+            "ram_available_mb": round(mem.available / 1e6),
+            "swap_used_mb": round(swap.used / 1e6),
+            "server_rss_mb": round(proc.memory_info().rss / 1e6, 1),
+            "cli_processes": cli_procs,
+            "precache_keys": len(_parcelas_geo_cache),
+            "chat_sessions": sessions.active_count,
+        },
+    }
 
 
 @app.get("/api/search", response_model=list[SearchResult])


### PR DESCRIPTION
## Summary
- /api/health now reports RAM, swap, CLI process count/RSS, precache keys, active sessions
- Chat logs gap time and token usage per SDK turn for latency diagnosis
- psutil added to requirements

## Test plan
- [ ] curl /api/health shows system block with metrics
- [ ] Chat logs show chat_turn entries with gap times