### PR TITLE
Fix swap thrashing: lazy CLI, lighter prompt, reduced precache

### DIFF
--- a/chat.py
+++ b/chat.py
@@ -79,45 +79,34 @@ desarrollo inmobiliario.
   una query" o "primero verifico" — pensa internamente y mostra solo el \
   resultado final.
 
-## Base de datos — tabla `parcelas`
+## Base de datos — tabla `parcelas` (280k rows)
 
 Columnas: {schema}
 
-Ejemplo (SELECT * FROM parcelas ORDER BY RANDOM() LIMIT 3):
-{sample}
-
-Notas clave:
-- epok_direccion = dirección completa (ej "JURAMENTO AV. 2100"). Para buscar: WHERE epok_direccion LIKE '%JURAMENTO%'
-- epok_altura = número de puerta (NO es la altura del edificio)
-- plano_san = altura máxima permitida (plano límite sanitizado)
-- delta_altura = plano_san - tejido_altura_max (subutilización)
-- smp = código catastral (ej "036-102-013"), smp_norm sin ceros (ej "36-102-13")
+Notas clave para queries SQL:
+- Buscar por dirección: WHERE epok_direccion LIKE '%JURAMENTO%' (ej "JURAMENTO AV. 2100")
+- epok_altura = número de puerta, NO es la altura del edificio
+- plano_san = plano límite sanitizado (altura máxima permitida en metros)
+- delta_altura = plano_san - tejido_altura_max (brecha de subutilización)
+- smp = código catastral (ej "016-044-038"), smp_norm sin ceros (ej "16-44-38")
+- Buscar por SMP: WHERE smp_norm = '16-44-38'
+- NO uses SELECT * — seleccioná solo las columnas que necesitás
+- polygon_geojson es muy pesado — no lo incluyas en queries
 """
 
 
 def _build_system_prompt() -> str:
-    """Build system prompt with live schema + 3 sample rows."""
+    """Build system prompt with DB column names."""
     try:
         conn = sqlite3.connect(str(DB_PATH), timeout=5)
         conn.row_factory = sqlite3.Row
         cols = conn.execute("PRAGMA table_info(parcelas)").fetchall()
         schema = ", ".join(f'{c["name"]} ({c["type"]})' for c in cols)
-        rows = conn.execute(
-            "SELECT * FROM parcelas WHERE epok_direccion IS NOT NULL "
-            "ORDER BY RANDOM() LIMIT 3"
-        ).fetchall()
-        sample_rows = []
-        for r in rows:
-            d = dict(r)
-            d.pop("polygon_geojson", None)
-            d.pop("edif_linderas", None)
-            sample_rows.append(d)
-        sample = json.dumps(sample_rows, ensure_ascii=False, default=str)
         conn.close()
-        return _SYSTEM_PROMPT_TEMPLATE.format(schema=schema, sample=sample)
+        return _SYSTEM_PROMPT_TEMPLATE.format(schema=schema)
     except Exception as exc:
         logger.warning("Failed to build dynamic prompt: %s", exc)
-        return _SYSTEM_PROMPT_TEMPLATE.format(schema="(no disponible)", sample="[]")
+        return _SYSTEM_PROMPT_TEMPLATE.format(schema="(no disponible)")
 
 
 # ---------------------------------------------------------------------------
@@ -470,14 +459,8 @@ class SessionManager:
             pass  # Best-effort cleanup
 
     async def warmup(self) -> None:
-        """Pre-initialize the SDK CLI subprocess so first query is fast."""
-        logger.info("warmup: pre-initializing agent SDK")
-        warmup_id = "__warmup__"
-        try:
-            await self.get_or_create(warmup_id, "haiku")
-            logger.info("warmup: SDK ready")
-        except Exception as exc:
-            logger.warning("warmup failed: %s", exc)
+        """No-op. CLI initializes lazily on first chat request."""
+        logger.info("warmup: lazy mode (no CLI subprocess at startup)")
 
     @property
     def active_count(self) -> int:

--- a/docs/upgrade-disk-ssd.sh
+++ b/docs/upgrade-disk-ssd.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Upgrade edificia-server disk from pd-standard (HDD) to pd-balanced (SSD)
+# Requires ~5 min downtime. Cost: +$1.80/month ($1.20 → $3.00 for 30GB)
+#
+# Performance improvement:
+#   IOPS: 22.5 → 180 (8x)
+#   Throughput: 3.6 MB/s → 8.4 MB/s (2.3x)
+#
+# Run from local machine with gcloud auth.
+
+set -e
+
+ZONE="us-west1-a"
+INSTANCE="edificia-server"
+DISK="edificia-server"
+SNAPSHOT="edificia-disk-snapshot-$(date +%Y%m%d)"
+NEW_DISK="edificia-server-ssd"
+
+echo "Step 1: Stop instance"
+gcloud compute instances stop $INSTANCE --zone=$ZONE
+
+echo "Step 2: Create snapshot of current disk"
+gcloud compute disks snapshot $DISK --zone=$ZONE --snapshot-names=$SNAPSHOT
+
+echo "Step 3: Create new pd-balanced disk from snapshot"
+gcloud compute disks create $NEW_DISK \
+  --zone=$ZONE \
+  --source-snapshot=$SNAPSHOT \
+  --type=pd-balanced \
+  --size=30GB
+
+echo "Step 4: Detach old disk"
+gcloud compute instances detach-disk $INSTANCE --zone=$ZONE --disk=$DISK
+
+echo "Step 5: Attach new SSD disk"
+gcloud compute instances attach-disk $INSTANCE --zone=$ZONE --disk=$NEW_DISK --boot
+
+echo "Step 6: Start instance"
+gcloud compute instances start $INSTANCE --zone=$ZONE
+
+echo "Step 7: Wait for boot and verify"
+sleep 30
+gcloud compute ssh $INSTANCE --zone=$ZONE --command="python3 /home/juanwisznia/edificia/monitor.py"
+
+echo ""
+echo "Done. Old disk '$DISK' can be deleted after confirming everything works:"
+echo "  gcloud compute disks delete $DISK --zone=$ZONE"
+echo "  gcloud compute snapshots delete $SNAPSHOT"

--- a/monitor.py
+++ b/monitor.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""
+EdificIA production monitor — run via SSH or cron.
+
+Usage:
+    python3 monitor.py              # One-shot status
+    python3 monitor.py --watch 10   # Refresh every 10 seconds
+    python3 monitor.py --json       # Machine-readable output
+
+Reports: CPU load, RAM/swap, uvicorn status, CLI processes,
+precache state, nginx status, and recent errors.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+
+def get_memory():
+    """Parse /proc/meminfo for RAM and swap."""
+    info = {}
+    with open("/proc/meminfo") as f:
+        for line in f:
+            parts = line.split()
+            if len(parts) >= 2:
+                info[parts[0].rstrip(":")] = int(parts[1])  # kB
+    return {
+        "ram_total_mb": info.get("MemTotal", 0) // 1024,
+        "ram_used_mb": (info.get("MemTotal", 0) - info.get("MemAvailable", 0)) // 1024,
+        "ram_available_mb": info.get("MemAvailable", 0) // 1024,
+        "swap_total_mb": info.get("SwapTotal", 0) // 1024,
+        "swap_used_mb": (info.get("SwapTotal", 0) - info.get("SwapFree", 0)) // 1024,
+    }
+
+
+def get_load():
+    """Get CPU load averages."""
+    load1, load5, load15 = os.getloadavg()
+    return {"load_1m": round(load1, 2), "load_5m": round(load5, 2), "load_15m": round(load15, 2)}
+
+
+def get_uptime():
+    """Get system uptime in seconds."""
+    with open("/proc/uptime") as f:
+        return int(float(f.read().split()[0]))
+
+
+def get_processes():
+    """Find uvicorn and claude CLI processes with RSS."""
+    procs = {"uvicorn": [], "claude_cli": []}
+    for pid_dir in Path("/proc").iterdir():
+        if not pid_dir.name.isdigit():
+            continue
+        try:
+            cmdline = (pid_dir / "cmdline").read_text().replace("\0", " ").strip()
+            status = (pid_dir / "status").read_text()
+            rss_kb = 0
+            state = "?"
+            for line in status.splitlines():
+                if line.startswith("VmRSS:"):
+                    rss_kb = int(line.split()[1])
+                if line.startswith("State:"):
+                    state = line.split()[1]
+            rss_mb = round(rss_kb / 1024, 1)
+            pid = int(pid_dir.name)
+
+            if "uvicorn" in cmdline and "server:app" in cmdline:
+                procs["uvicorn"].append({"pid": pid, "rss_mb": rss_mb, "state": state})
+            elif "claude" in cmdline and "stream-json" in cmdline:
+                procs["claude_cli"].append({"pid": pid, "rss_mb": rss_mb, "state": state})
+        except (PermissionError, FileNotFoundError, ProcessLookupError, ValueError):
+            continue
+    return procs
+
+
+def check_http(port=8765, path="/api/health", timeout=5):
+    """Check if uvicorn responds locally."""
+    import urllib.request
+    try:
+        url = f"http://127.0.0.1:{port}{path}"
+        req = urllib.request.Request(url)
+        start = time.time()
+        with urllib.request.urlopen(req, timeout=timeout) as r:
+            body = r.read().decode()
+            elapsed = time.time() - start
+            try:
+                data = json.loads(body)
+                return {"status": "ok", "elapsed_s": round(elapsed, 2), "data": data}
+            except json.JSONDecodeError:
+                return {"status": "error", "elapsed_s": round(elapsed, 2), "body": body[:200]}
+    except Exception as e:
+        return {"status": "error", "error": str(e)}
+
+
+def get_recent_errors(n=5):
+    """Get last N error lines from journalctl."""
+    try:
+        result = subprocess.run(
+            ["journalctl", "-u", "edificia", "--no-pager", "-n", "50", "--since", "5 min ago"],
+            capture_output=True, text=True, timeout=5,
+        )
+        errors = [
+            line for line in result.stdout.splitlines()
+            if any(kw in line.lower() for kw in ["error", "exception", "traceback", "killed", "oom", "timeout"])
+        ]
+        return errors[-n:]
+    except Exception:
+        return []
+
+
+def get_precache_status():
+    """Check if precache completed by looking at recent logs."""
+    try:
+        result = subprocess.run(
+            ["journalctl", "-u", "edificia", "--no-pager", "-n", "200"],
+            capture_output=True, text=True, timeout=5,
+        )
+        lines = result.stdout.splitlines()
+        for line in reversed(lines):
+            if "precache: done" in line:
+                return {"status": "done", "log": line.strip()}
+            if "precache: starting" in line:
+                return {"status": "running", "log": line.strip()}
+        return {"status": "unknown"}
+    except Exception:
+        return {"status": "unknown"}
+
+
+def monitor():
+    """Collect all metrics."""
+    return {
+        "timestamp": time.strftime("%Y-%m-%d %H:%M:%S"),
+        "uptime_s": get_uptime(),
+        "load": get_load(),
+        "memory": get_memory(),
+        "processes": get_processes(),
+        "http_check": check_http(),
+        "precache": get_precache_status(),
+        "recent_errors": get_recent_errors(),
+    }
+
+
+def format_human(data):
+    """Pretty-print for terminal."""
+    mem = data["memory"]
+    load = data["load"]
+    procs = data["processes"]
+    http = data["http_check"]
+    precache = data["precache"]
+
+    ram_pct = round(mem["ram_used_mb"] / mem["ram_total_mb"] * 100) if mem["ram_total_mb"] else 0
+
+    lines = [
+        f"=== EdificIA Monitor — {data['timestamp']} (up {data['uptime_s'] // 60}m) ===",
+        f"",
+        f"CPU:  load {load['load_1m']} / {load['load_5m']} / {load['load_15m']}",
+        f"RAM:  {mem['ram_used_mb']}MB / {mem['ram_total_mb']}MB ({ram_pct}%) — {mem['ram_available_mb']}MB available",
+        f"Swap: {mem['swap_used_mb']}MB / {mem['swap_total_mb']}MB",
+        f"",
+        f"Uvicorn:  {len(procs['uvicorn'])} process(es)",
+    ]
+    for p in procs["uvicorn"]:
+        lines.append(f"  PID {p['pid']}: {p['rss_mb']}MB (state: {p['state']})")
+
+    lines.append(f"Claude CLI: {len(procs['claude_cli'])} process(es)")
+    total_cli_mb = sum(p["rss_mb"] for p in procs["claude_cli"])
+    for p in procs["claude_cli"]:
+        lines.append(f"  PID {p['pid']}: {p['rss_mb']}MB (state: {p['state']})")
+    if procs["claude_cli"]:
+        lines.append(f"  Total CLI: {total_cli_mb}MB")
+
+    lines.append(f"")
+    if http["status"] == "ok":
+        health = http.get("data", {})
+        sys_block = health.get("system", {})
+        lines.append(f"HTTP:     OK ({http['elapsed_s']}s)")
+        if sys_block:
+            lines.append(f"  Precache keys: {sys_block.get('precache_keys', '?')}")
+            lines.append(f"  Chat sessions: {sys_block.get('chat_sessions', '?')}")
+    else:
+        lines.append(f"HTTP:     FAIL — {http.get('error', http.get('body', '?'))}")
+
+    lines.append(f"Precache: {precache['status']}")
+    if precache.get("log"):
+        lines.append(f"  {precache['log']}")
+
+    if data["recent_errors"]:
+        lines.append(f"")
+        lines.append(f"Recent errors:")
+        for e in data["recent_errors"]:
+            lines.append(f"  {e}")
+
+    return "\n".join(lines)
+
+
+if __name__ == "__main__":
+    if "--json" in sys.argv:
+        print(json.dumps(monitor(), indent=2))
+    elif "--watch" in sys.argv:
+        try:
+            idx = sys.argv.index("--watch")
+            interval = int(sys.argv[idx + 1]) if idx + 1 < len(sys.argv) else 10
+        except (ValueError, IndexError):
+            interval = 10
+        while True:
+            os.system("clear")
+            print(format_human(monitor()))
+            time.sleep(interval)
+    else:
+        print(format_human(monitor()))

--- a/server.py
+++ b/server.py
@@ -164,22 +164,27 @@ async def startup_background_tasks():
 _cleanup_task: asyncio.Task[None] | None = None
 
 
+_TOP_BARRIOS = [
+    "Palermo", "Belgrano", "Caballito", "Recoleta", "Villa Urquiza",
+    "Nuñez", "Almagro", "Villa Crespo", "Flores", "Balvanera",
+    "Saavedra", "Colegiales", "Boedo", "Villa Devoto", "Barracas",
+]
+
 async def _delayed_precache() -> None:
-    """Precache parcelas_geo one barrio at a time, yielding between each."""
+    """Precache top barrios only to reduce I/O at startup."""
     await asyncio.sleep(3)
     log = logging.getLogger("edificia.cache")
-    log.info("precache: starting")
+    log.info("precache: starting (%d barrios)", len(_TOP_BARRIOS))
     list_barrios()
-    barrios = _barrios_cache or []
-    for b in barrios:
+    for name in _TOP_BARRIOS:
         try:
             await asyncio.get_event_loop().run_in_executor(
-                None, lambda name=b["name"]: parcelas_geo(barrio=name, metric="delta", limit=3000)
+                None, lambda n=name: parcelas_geo(barrio=n, metric="delta", limit=3000)
             )
         except Exception:
             pass
-        await asyncio.sleep(0.1)  # Yield to event loop between barrios
-    log.info("precache: done (%d barrios)", len(barrios))
+        await asyncio.sleep(0.5)  # More yielding to reduce I/O pressure
+    log.info("precache: done (%d barrios)", len(_TOP_BARRIOS))
 
 
 def _warmup_sync() -> None:
@@ -526,8 +531,6 @@ def root() -> RedirectResponse:
 
 @app.get("/api/health")
 def health() -> dict[str, Any]:
-    import psutil
-
     with db_connect() as conn:
         total = conn.execute("SELECT COUNT(*) FROM parcelas").fetchone()[0]
         cur3d = conn.execute(
@@ -537,35 +540,28 @@ def health() -> dict[str, Any]:
             "SELECT COUNT(*) FROM parcelas WHERE COALESCE(epok_enriched, 0) = 1"
         ).fetchone()[0]
 
-    # System metrics
-    mem = psutil.virtual_memory()
-    swap = psutil.swap_memory()
-    proc = psutil.Process()
-    cli_procs = []
-    for child in proc.children(recursive=True):
-        try:
-            cmd = " ".join(child.cmdline())
-            if "claude" in cmd:
-                cli_procs.append({"pid": child.pid, "rss_mb": round(child.memory_info().rss / 1e6, 1), "status": child.status()})
-        except (psutil.NoSuchProcess, psutil.AccessDenied):
-            pass
-
-    return {
-        "ok": True,
-        "total": total,
-        "epok": epok,
-        "cur3d": cur3d,
-        "system": {
-            "ram_total_mb": round(mem.total / 1e6),
-            "ram_used_mb": round(mem.used / 1e6),
-            "ram_available_mb": round(mem.available / 1e6),
-            "swap_used_mb": round(swap.used / 1e6),
-            "server_rss_mb": round(proc.memory_info().rss / 1e6, 1),
-            "cli_processes": cli_procs,
-            "precache_keys": len(_parcelas_geo_cache),
-            "chat_sessions": sessions.active_count,
-        },
+    # Lightweight system metrics from /proc (no psutil)
+    system: dict[str, Any] = {
+        "precache_keys": len(_parcelas_geo_cache),
+        "chat_sessions": sessions.active_count,
     }
+    try:
+        with open("/proc/meminfo") as f:
+            mi = {}
+            for line in f:
+                parts = line.split()
+                if len(parts) >= 2:
+                    mi[parts[0].rstrip(":")] = int(parts[1])
+            system["ram_total_mb"] = mi.get("MemTotal", 0) // 1024
+            system["ram_available_mb"] = mi.get("MemAvailable", 0) // 1024
+            system["swap_used_mb"] = (mi.get("SwapTotal", 0) - mi.get("SwapFree", 0)) // 1024
+        with open("/proc/loadavg") as f:
+            parts = f.read().split()
+            system["load_1m"] = float(parts[0])
+    except Exception:
+        pass
+
+    return {"ok": True, "total": total, "epok": epok, "cur3d": cur3d, "system": system}
 
 
 @app.get("/api/search", response_model=list[SearchResult])


### PR DESCRIPTION
## Root cause (with evidence)
- I/O wait 96-99% (vmstat)
- pd-standard HDD, 36 IOPS
- CLI warmup 130MB committed (50 RSS + 82 swap)
- DB grew to 556MB from CUR3D enrichment
- RAM is NOT the issue (519MB available)

## Fixes
- Lazy CLI init (no subprocess at startup) — saves 130MB
- System prompt: 11.7K → ~3K chars (removed sample rows, kept column names)
- Health endpoint: /proc reads instead of psutil (no blocking on swap thrash)
- Precache: 47 → 15 top barrios (less I/O pressure at boot)
- monitor.py for production observability

## Test plan
- [ ] Server boots without Claude CLI process
- [ ] /api/health responds fast
- [ ] Barrios load on map
- [ ] Chat works on first request (lazy init)
- [ ] `python3 monitor.py` shows system metrics