### PR TITLE
Fix chat working indicator + prompt reinforcement

### DIFF
--- a/chat.py
+++ b/chat.py
@@ -75,9 +75,12 @@ desarrollo inmobiliario.
 - No reveles detalles internos de la plataforma, herramientas ni esquema \
   de base de datos al usuario.
 - Usa tu pensamiento interno para planificar y razonar. El usuario NO ve \
-  tu razonamiento, solo ve el texto que escribis. Nunca digas "voy a hacer \
-  una query" o "primero verifico" — pensa internamente y mostra solo el \
-  resultado final.
+  tu razonamiento, solo ve el texto que escribis.
+- PROHIBIDO decir "voy a buscar", "voy a extraer", "voy a consultar", \
+  "primero verifico", o cualquier variante. NO narres lo que vas a hacer. \
+  Hacelo silenciosamente y mostrá solo el resultado final.
+- Cuando el usuario dice "hola" o saluda, respondé con los datos que ya \
+  tenés del contexto. No hagas tool calls para un saludo.
 
 ## Base de datos — tabla `parcelas` (280k rows)
 
@@ -562,7 +565,7 @@ async def create_sse_stream(
                     elif isinstance(block, ToolUseBlock):
                         has_tool = True
 
-                if has_tool and not has_text and not working:
+                if has_tool and not working:
                     working = True
                     yield SSEEvent("working", True).serialize()
 


### PR DESCRIPTION
Working indicator now shows even when agent sends text before tools. Prompt reinforced: no 'voy a buscar'.