### PR TITLE
Manzana click-to-zoom + print CSS

### DIFF
--- a/index.html
+++ b/index.html
@@ -688,6 +688,167 @@
       #full-report-modal #report-chat-container{position:static;width:100%;height:320px;border-left:none;border-top:1px solid #333;box-shadow:none}
     }
 
+    /* ══════════════════════════════════════════════════════════
+       PRINT STYLES — Ctrl+P / Save as PDF
+       ══════════════════════════════════════════════════════════ */
+    @media print{
+      /* Hide non-printable elements */
+      header,
+      .viewport,
+      .search-panel,
+      #results,
+      .panel,
+      #chat-toggle,
+      #report-chat-container,
+      #pdf-btn-wrap,
+      #btn-download-pdf,
+      #close-full-report,
+      .frm-calc-reset,
+      #rc-model{display:none !important}
+
+      /* Reset body for print */
+      body{background:#fff !important;color:#1a1a1a !important;overflow:visible !important;height:auto !important}
+
+      /* Modal becomes the full page */
+      #full-report-modal,
+      #full-report-modal.formal-report,
+      .formal-report{
+        display:block !important;position:static !important;
+        width:100% !important;height:auto !important;
+        overflow:visible !important;background:#fff !important;
+        z-index:auto !important;
+      }
+
+      /* Header bar in report */
+      #frm-header{
+        position:static !important;background:#fff !important;
+        border-bottom:2px solid #1a1a1a !important;
+        padding:12px 20px !important;
+      }
+      .frm-header-logo div{color:#1a1a1a !important}
+      .frm-header-logo svg rect{stroke:#1a1a1a !important}
+      .frm-header-logo svg path{stroke:#1a1a1a !important}
+      .frm-header-logo small{color:#555 !important}
+
+      /* Body padding */
+      .frm-body{padding:20px !important;max-width:100% !important}
+      .frm-with-chat{display:block !important}
+      .frm-main-col{width:100% !important}
+
+      /* Hero section */
+      .frm-hero-row{
+        background:#f8f8f8 !important;border:1px solid #ddd !important;
+        box-shadow:none !important;border-radius:8px !important;
+        padding:20px 24px !important;break-inside:avoid;
+      }
+      .frm-eyebrow{color:#777 !important}
+      .frm-hero-address{color:#1a1a1a !important}
+      .frm-hero-badge{
+        background:rgba(255,191,0,.12) !important;color:#996f00 !important;
+        border:1px solid #FFBF00 !important;
+      }
+
+      /* Circular map — preserve for print */
+      .frm-map-ring{border:1px solid #ccc !important;box-shadow:none !important}
+      .frm-map-ring::after{display:none !important}
+      .frm-map-clip{background:#eee !important}
+      .frm-coords{color:#999 !important}
+
+      /* M2 cards */
+      .frm-cards-row{gap:12px !important;margin-bottom:16px !important}
+      .frm-card{
+        background:#f8f8f8 !important;border:1px solid #ddd !important;
+        box-shadow:none !important;border-radius:8px !important;
+        break-inside:avoid;
+      }
+      .frm-card-label{color:#996f00 !important}
+      .frm-card-val{color:#1a1a1a !important}
+      .frm-card.total .frm-card-val{color:#996f00 !important}
+      .frm-card-unit,.frm-card-sub{color:#777 !important}
+
+      /* Normative table */
+      .frm-table-card{
+        background:#f8f8f8 !important;border:1px solid #ddd !important;
+        box-shadow:none !important;border-radius:8px !important;
+        break-inside:avoid;
+      }
+      .frm-table-title{color:#996f00 !important;border-bottom:1px solid #FFBF00 !important}
+      .frm-table-title svg{stroke:#996f00 !important}
+      .frm-table-item{
+        background:#fff !important;border:1px solid #eee !important;
+      }
+      .frm-table-item label{color:#996f00 !important}
+      .frm-table-item p{color:#1a1a1a !important}
+
+      /* Analysis cards */
+      .frm-analysis{break-inside:avoid}
+      .frm-analysis-card{
+        background:#f8f8f8 !important;border:1px solid #ddd !important;
+        box-shadow:none !important;border-radius:8px !important;
+        break-inside:avoid;
+      }
+      .frm-analysis-item{border-bottom:1px solid #eee !important}
+      .frm-analysis-item span:first-child{color:#777 !important}
+      .frm-analysis-item span:last-child{color:#1a1a1a !important}
+      .frm-plusvalia-usd{color:#1a1a1a !important}
+      .frm-plusvalia-uva{color:#999 !important}
+
+      /* Croquis */
+      .frm-croquis{
+        background:#f8f8f8 !important;border:1px solid #ddd !important;
+        box-shadow:none !important;border-radius:8px !important;
+        break-inside:avoid;
+      }
+      .croquis-link{
+        color:#996f00 !important;border:1px solid #FFBF00 !important;
+        background:#fff !important;
+      }
+
+      /* Enrase */
+      #frm-enrase-bloque .frm-analysis-card{
+        background:#f8f8f8 !important;border:1px solid #ddd !important;
+        box-shadow:none !important;
+      }
+      #frm-enrase-contenido,#frm-enrase-contenido span{color:#1a1a1a !important}
+
+      /* Feasibility calculator */
+      .frm-calc-section{
+        background:#f8f8f8 !important;border:1px solid #ddd !important;
+        box-shadow:none !important;border-radius:8px !important;
+        break-inside:avoid;
+      }
+      .frm-calc-title{color:#996f00 !important}
+      .frm-calc-title svg{stroke:#996f00 !important}
+      .frm-calc-label{color:#996f00 !important}
+      .frm-calc-input{
+        background:#fff !important;border:1px solid #ccc !important;
+        color:#1a1a1a !important;
+      }
+      .frm-macro-bar{background:#f0f0f0 !important;border:1px solid #ddd !important}
+      .frm-macro-label{color:#777 !important}
+      .frm-macro-val{color:#1a1a1a !important}
+      .frm-macro-sep{background:#ccc !important}
+      .frm-macro-live-label{color:#777 !important}
+      .frm-calc-result{
+        background:#fff !important;border:1px solid #eee !important;
+        border-radius:8px !important;
+      }
+      .frm-calc-result-label{color:#777 !important}
+      .frm-calc-result-val{color:#1a1a1a !important}
+      .frm-calc-result.highlight{background:#fffbeb !important;border:1px solid #FFBF00 !important}
+      .frm-calc-result.highlight .frm-calc-result-val{color:#996f00 !important}
+      #fc-r-ganancia{color:#1a1a1a !important}
+
+      /* Footer */
+      .frm-footer-note{color:#999 !important;border-top:1px solid #ddd !important}
+
+      /* Global print resets */
+      *{-webkit-print-color-adjust:exact !important;print-color-adjust:exact !important}
+
+      /* Leaflet tiles — force print */
+      .leaflet-tile-container img{-webkit-print-color-adjust:exact !important;print-color-adjust:exact !important}
+    }
+
   </style>
 </head>
 <body>

--- a/server.py
+++ b/server.py
@@ -839,6 +839,56 @@ _barrios_cache: list[dict[str, Any]] | None = None
 _parcelas_geo_cache: dict[str, dict[str, Any]] = {}  # barrio -> geojson
 
 
+@app.get("/api/manzana_geo/{seccion_mzna}")
+def manzana_geo(seccion_mzna: str, metric: str = Query("delta")) -> dict[str, Any]:
+    """Return GeoJSON of all parcels in a single manzana (block)."""
+    metric_col = {
+        "delta": "CASE WHEN tejido_altura_max IS NOT NULL THEN plano_san - tejido_altura_max ELSE 0 END",
+        "vol": "COALESCE(vol_edificable, 0)",
+        "pisos": "COALESCE(pisos, 0)",
+        "area": "COALESCE(area, 0)",
+    }.get(metric, "COALESCE(plano_san - COALESCE(tejido_altura_max, 0), 0)")
+
+    with db_connect() as conn:
+        rows = conn.execute(
+            f"""SELECT smp, lat, lng, polygon_geojson,
+                cpu, barrio, area, pisos, plano_san, tejido_altura_max,
+                vol_edificable, sup_vendible, fot, uso_tipo1, uso_tipo2, epok_direccion,
+                frente, fondo, delta_pisos, epok_pisos_sobre,
+                es_aph, edif_catalogacion_proteccion, edif_riesgo_hidrico,
+                edif_enrase, edif_plusvalia_incidencia_uva, edif_plusvalia_alicuota,
+                {metric_col} as score
+            FROM parcelas
+            WHERE seccion_mzna = :sm AND polygon_geojson IS NOT NULL
+            ORDER BY {metric_col} DESC""",
+            {"sm": seccion_mzna},
+        ).fetchall()
+
+    features = []
+    for r in rows:
+        coords = json.loads(r["polygon_geojson"])
+        features.append({
+            "type": "Feature",
+            "geometry": {"type": "Polygon", "coordinates": [coords]},
+            "properties": {
+                "smp": r["smp"], "score": r["score"],
+                "barrio": r["barrio"], "cpu": r["cpu"],
+                "area": r["area"], "pisos": r["pisos"],
+                "plano_san": r["plano_san"], "tejido": r["tejido_altura_max"],
+                "vol": r["vol_edificable"], "vendible": r["sup_vendible"],
+                "fot": r["fot"], "uso1": r["uso_tipo1"], "uso2": r["uso_tipo2"],
+                "dir": r["epok_direccion"], "fr": r["frente"], "fo": r["fondo"],
+                "dp": r["delta_pisos"], "pisos_e": r["epok_pisos_sobre"],
+                "aph": r["es_aph"], "cat": r["edif_catalogacion_proteccion"],
+                "rh": r["edif_riesgo_hidrico"], "enrase": r["edif_enrase"],
+                "plusv_uva": r["edif_plusvalia_incidencia_uva"],
+                "plusv_al": r["edif_plusvalia_alicuota"],
+            },
+        })
+
+    return {"type": "FeatureCollection", "features": features}
+
+
 @app.get("/api/barrios")
 def list_barrios() -> list[dict[str, Any]]:
     global _barrios_cache

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -25,6 +25,7 @@ let _activeBarrio = null;
 let _selectedSmp = null;
 let _filters = {};
 let _callbacks = {};
+let _activeManzana = null;  // seccion_mzna when zoomed into a block
 
 // ── Constants ────────────────────────────────────────────────────
 
@@ -138,16 +139,16 @@ export function renderCircles() {
 
   _circleLayer.addTo(_map);
 
-  // Single click handler on map for barrio selection (instead of per-marker)
+  // Click on heatmap → zoom to manzana → show individual parcels
   _map.off('click.heatmap');
   _map.on('click.heatmap', (e) => {
-    if (_activeBarrio || !_callbacks.onBarrioClick) return;
+    if (_activeBarrio) return;
     let best = null, bestD = Infinity;
     for (const mz of _manzanasData) {
       const d = (mz.lt - e.latlng.lat) ** 2 + (mz.ln - e.latlng.lng) ** 2;
       if (d < bestD) { bestD = d; best = mz; }
     }
-    if (best) _callbacks.onBarrioClick(best.b);
+    if (best) _zoomToManzana(best);
   });
 
   return { count, totalVol, avgDelta: dCount ? totalDelta / dCount : 0 };
@@ -205,6 +206,7 @@ export function setMetric(metricId) {
 
 export function setBarrio(barrio) {
   _activeBarrio = barrio || null;
+  _activeManzana = null;
   if (_activeBarrio) return loadParcels();
   _map.setView(CABA_CENTER, CABA_ZOOM);
   return renderCircles();
@@ -276,6 +278,66 @@ function _selectParcel(feature, layer) {
   if (_geoLayer) _geoLayer.resetStyle();
   layer.setStyle({ fillOpacity: 0.9, color: '#fff', weight: 2 });
   if (_callbacks.onParcelClick) _callbacks.onParcelClick(feature.properties);
+}
+
+async function _zoomToManzana(mz) {
+  _activeManzana = mz.sm;
+
+  // Smooth zoom to manzana centroid
+  _map.flyTo([mz.lt, mz.ln], 18, { duration: 1.0 });
+
+  // Fade out circles during zoom
+  if (_circleLayer) {
+    const el = _circleLayer.getPane?.()?.parentElement || _map.getPane('overlayPane');
+    if (el) {
+      el.style.transition = 'opacity 0.8s ease';
+      el.style.opacity = '0';
+    }
+  }
+
+  // Wait for zoom animation to settle
+  await new Promise(r => setTimeout(r, 900));
+
+  // Remove circles, load manzana parcels
+  if (_circleLayer) { _map.removeLayer(_circleLayer); _circleLayer = null; }
+  const el2 = _map.getPane('overlayPane');
+  if (el2) { el2.style.transition = ''; el2.style.opacity = '1'; }
+
+  try {
+    const resp = await fetch(`/api/manzana_geo/${encodeURIComponent(mz.sm)}?metric=${_activeMetric}`);
+    if (!resp.ok) throw new Error(`${resp.status}`);
+    const geojson = await resp.json();
+
+    const { p5, p95 } = percentileBounds(geojson.features.map(f => f.properties.score));
+    _geoLayer = L.geoJSON(geojson, {
+      style: feature => _parcelStyle(feature, p5, p95),
+      onEachFeature: (feature, layer) => {
+        layer.on('click', () => _selectParcel(feature, layer));
+        layer.on('mouseover', () => {
+          if (feature.properties.smp !== _selectedSmp)
+            layer.setStyle({ fillOpacity: 0.75, color: 'rgba(255,255,255,0.5)', weight: 1 });
+        });
+        layer.on('mouseout', () => {
+          if (feature.properties.smp !== _selectedSmp) _geoLayer.resetStyle(layer);
+        });
+      },
+    }).addTo(_map);
+
+    if (geojson.features.length) {
+      _map.fitBounds(_geoLayer.getBounds(), { padding: [60, 60], maxZoom: 19 });
+    }
+  } catch (e) {
+    console.warn('Manzana load failed:', e);
+    // Fallback: load full barrio
+    if (_callbacks.onBarrioClick) _callbacks.onBarrioClick(mz.b);
+  }
+}
+
+function _exitManzana() {
+  _activeManzana = null;
+  _clearLayers();
+  _map.setView(CABA_CENTER, CABA_ZOOM, { duration: 0.8 });
+  setTimeout(() => renderCircles(), 300);
 }
 
 function _computeStats(features) {


### PR DESCRIPTION
## Changes
1. **Click manzana → zoom → show lotes**: Click a heatmap circle → smooth zoom → circles fade → individual parcel polygons appear. New `/api/manzana_geo/{seccion_mzna}` endpoint (~30 parcels/block).
2. **Print CSS**: Ctrl+P prints the report with white bg, dark text, no chat/buttons. `break-inside:avoid` on cards.

## Test plan
- [ ] Click a circle on the heatmap → zoom → parcels appear
- [ ] Click a parcel → detail panel opens
- [ ] "Todo CABA" resets to heatmap view
- [ ] Open report → Ctrl+P → preview shows clean white layout