### PR TITLE
Fix: consistent vendible values across panel/report/simulator

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -481,7 +481,7 @@ export function recalculate() {
   let eficiencia = 0.78 - 0.02 * Math.max(0, density - 5) + 0.002 * Math.max(0, fr_eff - 8);
   eficiencia = Math.max(0.55, Math.min(0.95, eficiencia));
 
-  const vendibleCubierto = volumen * eficiencia;
+  let vendibleCubierto = volumen * eficiencia;
 
   // Balconies
   const anchoBalcon = Math.max(0, (_frente || 0) - 1.20);


### PR DESCRIPTION
## Root cause
`const vendibleCubierto` crashed silently when reassigned
in the DB source-of-truth block.

## Verification (10 parcels, localhost)
All YES — panel, report, and simulator show identical values:
- Junin 1490: 2,055 / 2,055 / 2055
- Acoyte 960: 1,703 / 1,703 / 1703
- Corrientes 4585: 1,252 / 1,252 / 1252
- Santa Fe 3200: 2,065 / 2,065 / 2065
- Callao 1200: 1,422 / 1,422 / 1422
- Rivadavia 5000: 2,783 / 2,783 / 2783
- Mitre 4183: 1,235 / 1,235 / 1235
- Guatemala 4213: 972 / 972 / 972
- Anchoris 208: 93,565 / 93,565 / 93565
- Libertador 1052: 13,503 / 13,503 / 13503