### PR TITLE
Fix enrase: skip linderos fetch when not applicable

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -1187,8 +1187,12 @@ async function calcularEnrase(parcel) {
 
   if (!parcel?.smp) return resultado;
 
-  // Verificar flag de enrase en los datos de la parcela
+  // Si la DB dice que no aplica enrase, no consultar linderos
   const enraseFlag = parcel.edif_enrase || window._currentParcelData?.edif_enrase;
+  if (enraseFlag === 0 || enraseFlag === false) {
+    resultado.mensaje = 'No aplica enrase para esta parcela.';
+    return resultado;
+  }
 
   const smp     = parcel.smp;
   const cpu     = parcel.cpu || '';


### PR DESCRIPTION
85% of parcels don't have enrase — skip the slow /api/linderos fetch.